### PR TITLE
bwrap sandbox support

### DIFF
--- a/CHANGE_v0.2.0.md
+++ b/CHANGE_v0.2.0.md
@@ -1,0 +1,410 @@
+# Changelog v0.2.0
+
+All changes from the initial commit (`29b9f68`, 197 lines) to `v0.2.0` (~510 lines).
+
+---
+
+## 1. Removed `read_file` and `write_file` tools — shell-only design
+
+The initial version exposed three tools to the LLM: `shell`, `read_file`, and `write_file`. v0.2.0 removes the two file tools entirely, leaving only `shell`.
+
+**Initial (3 tools):**
+```c
+static const char TOOLS[]=
+    "[{...\"name\":\"shell\",...},{...\"name\":\"read_file\",...},{...\"name\":\"write_file\",...}]";
+
+char *tool_execute(const char *name, const char *aj) {
+    cJSON *a = cJSON_Parse(aj);
+    if (!strcmp(name,"shell")) { ... }
+    else if (!strcmp(name,"read_file")) { ... }
+    else if (!strcmp(name,"write_file")) { ... }
+}
+```
+
+**v0.2.0 (1 tool):**
+```c
+static const char TOOLS_JSON[] =
+    "[{\"type\":\"function\",\"function\":{\"name\":\"shell\","
+    "\"description\":\"Run a shell command\","
+    "\"parameters\":{...}}}]";
+
+static char *tool_execute(const Config *cfg, const char *name, cJSON *arguments) {
+    if (strcmp(name, "shell") != 0) return NULL;
+    ...
+}
+```
+
+The LLM now uses `cat`, `tee`, `sed`, etc. through the shell for file operations. This follows the anti-framework philosophy: the shell is the only integration layer needed.
+
+---
+
+## 2. Bubblewrap sandbox for tool execution
+
+The initial version ran shell commands directly via `popen()` with no isolation. v0.2.0 adds optional sandboxing using [bubblewrap](https://github.com/containers/bubblewrap).
+
+**Initial (no sandbox):**
+```c
+char *fc = malloc(cl+8);
+memcpy(fc, f1->valuestring, cl);
+memcpy(fc+cl, " 2>&1", 6);
+FILE *fp = popen(fc, "r");
+```
+
+**v0.2.0 (bwrap sandbox):**
+```c
+if (cfg->sandbox_bwrap) {
+    // Write command to temp file to avoid quoting issues
+    snprintf(script_path, sizeof(script_path), "%s/.szc_cmd", cwd);
+    FILE *sf = fopen(script_path, "w");
+    fprintf(sf, "%s\n", command);
+
+    snprintf(cmd_buf, sizeof(cmd_buf),
+        "%s bwrap "
+        "--unshare-user-try --unshare-pid --unshare-ipc "
+        "--unshare-uts --unshare-cgroup-try "
+        "--die-with-parent --new-session "
+        "--tmpfs / "
+        "--bind %s /work "         // current dir -> /work
+        "--ro-bind /bin /bin "
+        "--ro-bind /usr /usr "
+        "--ro-bind /lib /lib --ro-bind /lib64 /lib64 "
+        "--dev /dev --proc /proc --tmpfs /tmp "
+        "%s "                      // optional: --unshare-net
+        "bash /work/.szc_cmd 2>&1",
+        timeout_str, cwd, skills_bind, net_str);
+} else {
+    snprintf(cmd_buf, sizeof(cmd_buf), "%s 2>&1", command);
+}
+```
+
+Three new config options control sandbox behavior:
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `sandbox_bwrap` | 1 | Enable bubblewrap isolation |
+| `sandbox_net` | 1 | Block external network (localhost only) |
+| `sandbox_timeout` | 60 | Kill commands after N seconds |
+
+The sandbox mounts the current directory as `/work`, provides read-only access to system binaries, and optionally isolates networking with `--unshare-net`.
+
+---
+
+## 3. Config struct and parsing refactored for readability
+
+The initial version used cryptic short field names. v0.2.0 uses full descriptive names and adds sandbox fields.
+
+**Initial:**
+```c
+typedef struct { char key[MV],model[MV],ep[MV],skills[MP],logdir[MP]; int mt,mm,ck; } Cfg;
+```
+
+**v0.2.0:**
+```c
+typedef struct {
+    char api_key[MAX_VALUE], model[MAX_VALUE], endpoint[MAX_VALUE];
+    char skills_dir[MAX_PATH], log_dir[MAX_PATH];
+    int  max_turns, max_messages;
+    int sandbox_bwrap;
+    int sandbox_net;
+    int sandbox_timeout;
+} Config;
+```
+
+The parser (`config_parse_line`) is now a separate function, and environment variable overrides are added for all sandbox options (`SUBZEROCLAW_SANDBOX_BWRAP`, `SUBZEROCLAW_SANDBOX_NET`, `SUBZEROCLAW_SANDBOX_TIMEOUT`).
+
+---
+
+## 4. Readable code style throughout
+
+The initial version was aggressively compressed into 197 lines. v0.2.0 reformats everything for readability with proper indentation, spacing, and named constants.
+
+**Initial (compressed):**
+```c
+#define MP 512
+#define MV 1024
+#define MR (128*1024)
+
+static void logw(FILE *f,const char *r,const char *c){if(!f)return;time_t n=time(0);
+    struct tm *t=localtime(&n);char ts[32];strftime(ts,32,"%Y-%m-%d %H:%M:%S",t);
+    fprintf(f,"[%s] %s: %s\n",ts,r,c);fflush(f);}
+```
+
+**v0.2.0 (readable):**
+```c
+#define MAX_PATH   512
+#define MAX_VALUE  1024
+#define MAX_OUTPUT (128 * 1024)
+
+static void log_write(FILE *log, const char *role, const char *content) {
+    if (!log) return;
+    time_t now = time(NULL);
+    struct tm *t = localtime(&now);
+    char ts[32]; strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", t);
+    fprintf(log, "[%s] %s: %s\n", ts, role, content); fflush(log);
+}
+```
+
+All functions follow this pattern: `build_req` -> `build_request`, `parse_resp` -> `parse_response`, `compact` -> `compact_messages`, `logw` -> `log_write`, etc.
+
+---
+
+## 5. Secure HTTP posting (API key no longer in command line)
+
+The initial version passed the API key directly in the curl command line, visible in `ps` output:
+
+**Initial:**
+```c
+snprintf(cmd, 2048, "curl -s -m 120 -H 'Authorization: Bearer %s' "
+    "-H 'Content-Type: application/json' -d @/tmp/.szc.json '%s' 2>&1", key, url);
+```
+
+**v0.2.0:**
+```c
+// Write header to temp file — API key never appears in process list
+char hdr[MAX_VALUE + 64];
+snprintf(hdr, sizeof(hdr), "-H \"Authorization: Bearer %s\"", api_key);
+write_temp("hdr", hdr, hdr_path, sizeof(hdr_path));
+
+snprintf(cmd, sizeof(cmd),
+    "curl -s -m 120 -K '%s' -H 'Content-Type: application/json' -d @'%s' '%s' 2>&1",
+    hdr_path, body_path, url);
+```
+
+The `-K` flag tells curl to read the authorization header from a file. Both temp files use `mkstemp()` for unique names (instead of the fixed `/tmp/.szc.json`), preventing race conditions when running multiple instances.
+
+---
+
+## 6. Project-local skills support
+
+The initial version only loaded skills from one global directory (`~/.subzeroclaw/skills/`). v0.2.0 adds a second skill source: the `skills/` directory in the current working directory.
+
+**Initial:**
+```c
+char *agent_build_system_prompt(const char *dir) {
+    // loads skills from one directory only
+}
+```
+
+**v0.2.0:**
+```c
+char *agent_build_system_prompt(const char *skills_dir, const char *project_skills_dir) {
+    ...
+    len = load_skills(&prompt, len, &cap, skills_dir, "SKILL");
+    len = load_skills(&prompt, len, &cap, project_skills_dir, "PROJECT SKILL");
+    return prompt;
+}
+```
+
+The `load_skills` function is extracted as a reusable helper that scans a directory for `.md` files and appends them to the system prompt. Global skills are labeled `SKILL`, project-local ones `PROJECT SKILL`.
+
+---
+
+## 7. Tool argument parsing handles both string and object formats
+
+Some LLM APIs return tool call arguments as a JSON string (double-encoded), others as a parsed JSON object. The initial version only handled string arguments. v0.2.0 handles both.
+
+**v0.2.0:**
+```c
+static int process_tool_calls(const Config *cfg, cJSON *tool_calls, cJSON *msgs, FILE *log) {
+    ...
+    cJSON *args_parsed = NULL;
+    if (cJSON_IsString(args)) {
+        args_parsed = cJSON_Parse(args->valuestring);
+        if (args_parsed) args = args_parsed;
+    } else if (!cJSON_IsObject(args)) {
+        continue;
+    }
+    char *result = tool_execute(cfg, name->valuestring, args);
+    if (args_parsed) cJSON_Delete(args_parsed);
+    ...
+}
+```
+
+This makes SubZeroClaw compatible with more API providers (OpenRouter, OpenAI, xAI, etc.).
+
+---
+
+## 8. Improved context compaction
+
+The initial compaction used a simple boundary-based approach that kept the last N messages and discarded the rest. v0.2.0 sends old messages to the LLM for summarization with trimming of long tool outputs.
+
+**Initial:**
+```c
+static int compact(const Cfg *c, cJSON *msgs, FILE *log) {
+    int bnd = tot - c->ck;
+    // collect messages 1..bnd into text, delete them
+    // insert summary at position 1
+}
+```
+
+**v0.2.0:**
+```c
+static int compact_messages(const Config *cfg, cJSON *msgs, FILE *log) {
+    // Trim long tool outputs in the summary input
+    if (strcmp(r, "tool") == 0 && clen > 2000) {
+        memcpy(convo + len, c, 1000);
+        len += snprintf(convo + len, cap - len, "... [trimmed] ...\n");
+    }
+    // Keep last 10 messages, summarize the rest
+    while (cJSON_GetArraySize(msgs) > 10) {
+        cJSON_DeleteItemFromArray(msgs, 0);
+    }
+    cJSON_InsertItemInArray(msgs, 0, make_msg("assistant", resp.text));
+    cJSON_InsertItemInArray(msgs, 0, make_msg("user", summary_prompt));
+}
+```
+
+Tool outputs longer than 2000 characters are truncated to 1000 before being sent for summarization, reducing token usage.
+
+---
+
+## 9. Readline integration for interactive mode
+
+The initial version used raw `fgets()` for interactive input. v0.2.0 uses GNU readline for line editing, history, and arrow key navigation.
+
+**Initial:**
+```c
+printf("> "); fflush(stdout);
+if (!fgets(in, 4096, stdin)) break;
+```
+
+**v0.2.0:**
+```c
+#include <readline/readline.h>
+#include <readline/history.h>
+...
+char *line = readline("> ");
+if (!line) break;
+if (line[0]) add_history(line);
+agent_run(&cfg, line, log);
+free(line);
+```
+
+This adds proper terminal line editing (Ctrl-A, Ctrl-E, backspace, arrow keys) and command history (up/down arrows) to the interactive REPL.
+
+---
+
+## 10. Timestamped session IDs
+
+The initial version generated random hex session IDs from `/dev/urandom`. v0.2.0 uses human-readable timestamps.
+
+**Initial:**
+```c
+FILE *r = fopen("/dev/urandom","r");
+unsigned char b[8];
+fread(b, 1, 8, r);
+snprintf(sid, 32, "%02x%02x%02x%02x%02x%02x%02x%02x", b[0],...);
+```
+
+**v0.2.0:**
+```c
+time_t now = time(NULL);
+struct tm *tm = localtime(&now);
+strftime(session_id, sizeof(session_id), "%Y%m%dT%H%M%S", tm);
+```
+
+Log files are now named like `20260222T153001.txt` instead of `f850c58ddd4ae72a.txt`, making them easy to find by date.
+
+---
+
+## 11. `--version` flag with license info
+
+**v0.2.0:**
+```c
+if (argc == 2 && (!strcmp(argv[1], "--version") || !strcmp(argv[1], "-v"))) {
+    printf("subzeroclaw %s\n"
+           "Copyright (c) 2025-2026 SubZeroClaw contributors\n"
+           "License MIT: https://opensource.org/licenses/MIT\n"
+           "This is free software: you are free to change and redistribute it.\n"
+           "There is NO WARRANTY, to the extent permitted by law.\n",
+           SZC_VERSION);
+    return 0;
+}
+```
+
+---
+
+## 12. Agent loop restructured
+
+The initial version passed messages and tools arrays into `agent_run` from `main()`. v0.2.0 creates and manages them internally, keeping the public interface simpler.
+
+**Initial:**
+```c
+static int agent_run(const Cfg *c, cJSON *msgs, cJSON *tools, const char *in, FILE *log) {
+    compact(c, msgs, log);
+    cJSON_AddItemToArray(msgs, um);
+    for (int t = 0; ++t <= c->mt; ) { ... }
+}
+
+// in main():
+cJSON *msgs = cJSON_CreateArray();
+cJSON *tools = cJSON_Parse(TOOLS);
+agent_run(&cfg, msgs, tools, in, log);
+```
+
+**v0.2.0:**
+```c
+static int agent_run(const Config *cfg, const char *task, FILE *log) {
+    char *system_prompt = agent_build_system_prompt(cfg->skills_dir, project_skills);
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("system", system_prompt));
+    cJSON *tools = cJSON_Parse(TOOLS_JSON);
+    for (int turn = 1; turn <= cfg->max_turns; turn++) { ... }
+    cJSON_Delete(msgs); cJSON_Delete(tools);
+    return 0;
+}
+
+// in main():
+agent_run(&cfg, task, log);
+```
+
+Each call to `agent_run` now creates a fresh message array, which means context does not carry between separate invocations in interactive mode. This is a deliberate simplification.
+
+---
+
+## 13. Symlink replaced with real header wrapper
+
+The vendored `src/cjson/cJSON.h` was a symlink to `../cJSON.h`. v0.2.0 replaces it with a real file containing just an include directive, which is more portable across filesystems and archives.
+
+**Initial:** symlink `src/cjson/cJSON.h -> ../cJSON.h`
+
+**v0.2.0:**
+```c
+/* Vendored cJSON wrapper */
+#include "../cJSON.h"
+```
+
+---
+
+## 14. Makefile links readline
+
+```makefile
+# Before:
+LDFLAGS = -lm
+
+# After:
+LDFLAGS = -lm -lreadline
+```
+
+---
+
+## 15. Test suite expanded (14 -> 23 tests)
+
+New tests added for:
+- Sandbox execution (echo, workdir, no /home access, /bin access, workdir files, user skill creation, timeout)
+- Error handling (unknown tool returns NULL, missing command field, API error responses, garbage JSON input)
+- Request building (`build_request` structure validation)
+- Config validation (failure without API key)
+
+All tests updated to use the new `Config`-based `tool_execute` signature and the extracted `parse_response`/`build_request` functions.
+
+---
+
+## 16. Supporting files added
+
+- **`.env.example`** — template for environment variable setup
+- **`CONTRIBUTING.md`** — contribution guidelines explaining the anti-framework philosophy
+- **`.gitignore`** — expanded with editor files, build artifacts, macOS metadata
+- **`config.example`** — updated with sandbox options and new default model
+- **`szc-logo.png`** — project logo
+- **`README.md`** — rewritten with sandbox docs, updated stats, philosophy section

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ TARGET  = subzeroclaw
 # Use system libcjson if available, otherwise use vendored copy
 HAVE_SYSTEM_CJSON := $(shell pkg-config --exists libcjson 2>/dev/null && echo yes)
 ifeq ($(HAVE_SYSTEM_CJSON),yes)
-  LDFLAGS = -lcjson
+  LDFLAGS = -lcjson -lreadline
 else
   CFLAGS  += -Isrc
   VENDOR  = src/cJSON.c
-  LDFLAGS = -lm
+  LDFLAGS = -lm -lreadline
 endif
 
 # Single-file build (default)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **WARNING: This software executes arbitrary shell commands with no safety checks, no confirmation prompts, no sandboxing, and no guardrails. The LLM decides what to run and the runtime runs it — `rm -rf /` included. There is nothing between the model's output and your system. If you don't understand what that means, do not use this. This is a bare agentic loop: execute the task, whatever it takes, nothing more, nothing less.**
 
-**~380 lines of C. 54KB binary. A skill-driven agentic daemon for edge hardware.**
+**~470 lines of C. 54KB binary. A skill-driven agentic daemon for edge hardware.**
 
 ```
 skill.md + LLM + shell + loop = autonomous agent
@@ -37,7 +37,7 @@ SubZeroClaw doesn't simplify their architecture. It ignores it and writes the lo
 |                   | SubZeroClaw  | ZeroClaw     | OpenClaw     |
 |-------------------|--------------|--------------|--------------|
 | Language          | C            | Rust         | TypeScript   |
-| Source            | ~380 lines   | ~15,000      | ~430,000     |
+| Source            | ~470 lines   | ~15,000      | ~430,000     |
 | Binary            | 54 KB        | 3.4 MB       | 80+ MB       |
 | RAM (runtime)     | ~2 MB        | < 5 MB       | 80-120 MB    |
 | Compiles on Pi    | 0.5s         | OOM          | slow         |
@@ -78,6 +78,43 @@ make install    # copies to ~/.local/bin/
 
 Requires `libcjson-dev` or uses vendored cJSON automatically.
 
+### Sandbox (optional)
+
+SubZeroClaw can sandbox tool execution with [bubblewrap](https://github.com/containers/bubblewrap). Install it:
+
+```bash
+# Debian/Ubuntu
+sudo apt install bubblewrap
+
+# Arch
+sudo pacman -S bubblewrap
+
+# Fedora
+sudo dnf install bubblewrap
+```
+
+Enable in config:
+
+```ini
+[sandbox]
+sandbox_bwrap = 1
+sandbox_net = 0        # 1 = block external network
+sandbox_timeout = 30
+```
+
+**Ubuntu 24.04+:** AppArmor restricts unprivileged user namespaces by default, which breaks bwrap. Fix:
+
+```bash
+sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
+```
+
+To make it permanent:
+
+```bash
+echo 'kernel.apparmor_restrict_unprivileged_userns=0' | sudo tee /etc/sysctl.d/99-userns.conf
+sudo sysctl --system
+```
+
 ## Setup
 
 ```bash
@@ -85,7 +122,7 @@ mkdir -p ~/.subzeroclaw/skills
 
 cat > ~/.subzeroclaw/config << EOF
 api_key = "sk-or-your-openrouter-key"
-model = "minimax/minimax-m2.5"
+model = "grok-4-1-fast-reasoning"
 EOF
 ```
 
@@ -145,18 +182,21 @@ No vector DB. No embeddings. One API call to compress context.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `api_key` | (required) | OpenRouter API key |
-| `model` | `minimax/minimax-m2.5` | Any OpenAI-compatible model |
-| `endpoint` | `https://openrouter.ai/api/v1/chat/completions` | API endpoint |
+| `model` | `grok-4-1-fast-reasoning` | Any OpenAI-compatible model |
+| `endpoint` | `https://api.x.ai/v1/chat/completions` | API endpoint |
 | `skills_dir` | `~/.subzeroclaw/skills` | Path to skill markdown files |
 | `log_dir` | `~/.subzeroclaw/logs` | Session log directory |
 | `max_turns` | 200 | Max tool-call loops per input |
 | `max_messages` | 40 | Trigger context compaction |
+| `sandbox_bwrap` | 0 | Enable bubblewrap sandbox |
+| `sandbox_net` | 0 | Block external network in sandbox |
+| `sandbox_timeout` | 0 | Timeout per command in seconds (0 = none) |
 
 ## Source
 
 ```
 src/
-├── subzeroclaw.c   ~380 lines  The entire runtime
+├── subzeroclaw.c   ~470 lines  The entire runtime
 ├── test.c                      16 tests
 ├── watchdog.c       50 lines   Crash recovery + backoff
 ├── cJSON.c                     Vendored JSON parser

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The skills included in this repo (`skills/`) are just examples to show the forma
 ```bash
 make            # builds subzeroclaw (54KB)
 make watchdog   # builds watchdog (17KB)
-make test       # runs 16 tests
+make test       # runs 22 tests
 make install    # copies to ~/.local/bin/
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You write a skill as a markdown file. You point SubZeroClaw at it. It calls an L
 ```
 ~/.subzeroclaw/skills/monitor.md    ← what the agent knows
 ~/.subzeroclaw/config               ← API key + model
-~/.subzeroclaw/logs/<session>.txt   ← full I/O trace
+~/.subzeroclaw/logs/20260222T153001.txt  ← full I/O trace
 ```
 
 The agent reads the skill into its system prompt, receives input, and autonomously calls tools until the task is complete. When context gets full, it compacts old messages into a summary and keeps going.
@@ -72,11 +72,24 @@ The skills included in this repo (`skills/`) are just examples to show the forma
 ```bash
 make            # builds subzeroclaw (54KB)
 make watchdog   # builds watchdog (17KB)
-make test       # runs 22 tests
+make test       # runs 23 tests
 make install    # copies to ~/.local/bin/
 ```
 
-Requires `libcjson-dev` or uses vendored cJSON automatically.
+### Dependencies
+
+```bash
+# Debian/Ubuntu
+sudo apt install libreadline-dev libcjson-dev
+
+# Arch
+sudo pacman -S readline cjson
+
+# Fedora
+sudo dnf install readline-devel cjson-devel
+```
+
+`libreadline-dev` is required. `libcjson-dev` is optional — vendored cJSON is used automatically if not found.
 
 ### Sandbox (optional)
 
@@ -157,14 +170,14 @@ SUBZEROCLAW_ENDPOINT
 
 ## Session logging
 
-Every session gets a random hex ID. All input, output, tool calls, and results are logged to `~/.subzeroclaw/logs/<session>.txt` with timestamps.
+Every session gets a timestamped log file. All input, output, tool calls, and results are logged to `~/.subzeroclaw/logs/`.
 
 ```
-=== f850c58ddd4ae72a Sun Feb 16 16:30:01 2026
-[2026-02-16 16:30:01] USER: check disk usage
-[2026-02-16 16:30:03] TOOL: shell
-[2026-02-16 16:30:03] RES: /dev/sda1  72% /
-[2026-02-16 16:30:04] ASST: Disk usage is at 72%, below threshold.
+=== 20260216T163001 Sun Feb 16 16:30:01 2026
+[20260216T163001] USER: check disk usage
+[20260216T163003] TOOL: shell
+[20260216T163003] RES: /dev/sda1  72% /
+[20260216T163004] ASST: Disk usage is at 72%, below threshold.
 ```
 
 ## Context compaction

--- a/config.example
+++ b/config.example
@@ -1,8 +1,14 @@
 # SubZeroClaw configuration
 # Copy to ~/.subzeroclaw/config and edit
 
-api_key = "sk-or-your-openrouter-key-here"
-model = "minimax/minimax-m2.5"
-# endpoint = "https://openrouter.ai/api/v1/chat/completions"
-# skills_dir = "~/.subzeroclaw/skills"
-# max_turns = 50
+api_key = "your-api-key-here"
+model = "grok-4-1-fast-reasoning"
+endpoint = "https://api.x.ai/v1/chat/completions"
+skills_dir = "~/.subzeroclaw/skills"
+max_turns = 50
+
+
+[sandbox]
+sandbox_bwrap = 1      # Bubblewrap aktivieren (benötigt: apt install bubblewrap)
+sandbox_net = 0        # Nur localhost erlauben (externes Netzwerk blocken)
+sandbox_timeout = 30   # 30 Sekunden Timeout pro Befehl

--- a/src/cjson/cJSON.h
+++ b/src/cjson/cJSON.h
@@ -1,1 +1,2 @@
-../cJSON.h
+/* Vendored cJSON wrapper */
+#include "../cJSON.h"

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -14,6 +14,7 @@
 #include <readline/readline.h>
 #include <readline/history.h>
 
+#define SZC_VERSION "0.2.0"
 #define MAX_PATH   512
 #define MAX_VALUE  1024
 #define MAX_OUTPUT (128 * 1024)
@@ -464,6 +465,15 @@ static int agent_run(const Config *cfg, const char *task, FILE *log) {
 
 #ifndef SZC_TEST
 int main(int argc, char **argv) {
+    if (argc == 2 && (!strcmp(argv[1], "--version") || !strcmp(argv[1], "-v"))) {
+        printf("subzeroclaw %s\n"
+               "Copyright (c) 2025-2026 SubZeroClaw contributors\n"
+               "License MIT: https://opensource.org/licenses/MIT\n"
+               "This is free software: you are free to change and redistribute it.\n"
+               "There is NO WARRANTY, to the extent permitted by law.\n",
+               SZC_VERSION);
+        return 0;
+    }
     Config cfg;
     if (config_load(&cfg) < 0) return 1;
 

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -423,6 +423,7 @@ static int agent_run(const Config *cfg, const char *task, FILE *log) {
     return 0;
 }
 
+#ifndef SZC_TEST
 int main(int argc, char **argv) {
     Config cfg;
     if (config_load(&cfg) < 0) return 1;
@@ -465,3 +466,4 @@ int main(int argc, char **argv) {
     if (log) fclose(log);
     return 0;
 }
+#endif

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -11,6 +11,8 @@
 
 // NEW: Für getcwd (Sandbox CWD)
 #include <limits.h>   // PATH_MAX
+#include <readline/readline.h>
+#include <readline/history.h>
 
 #define MAX_PATH   512
 #define MAX_VALUE  1024
@@ -148,13 +150,21 @@ static char *tool_execute(const Config *cfg, const char *name, cJSON *arguments)
     if (!command_json || !cJSON_IsString(command_json)) return strdup("error: missing 'command'");
     const char *command = command_json->valuestring;
 
-    // NEW: Sandbox mit Bubblewrap + Timeout + optional localhost-only
+    // Sandbox mit Bubblewrap + Timeout + optional localhost-only
     char cmd_buf[8192];
     if (cfg->sandbox_bwrap) {
         char cwd[PATH_MAX];
         if (getcwd(cwd, sizeof(cwd)) == NULL) {
             return strdup("Failed to get current working directory for sandbox.");
         }
+        // Befehl in Temp-Datei schreiben (vermeidet Quoting-Probleme)
+        char script_path[PATH_MAX];
+        snprintf(script_path, sizeof(script_path), "%s/.szc_cmd", cwd);
+        FILE *sf = fopen(script_path, "w");
+        if (!sf) return strdup("Failed to create sandbox script.");
+        fprintf(sf, "%s\n", command);
+        fclose(sf);
+
         char timeout_str[32] = "";
         if (cfg->sandbox_timeout > 0) {
             snprintf(timeout_str, sizeof(timeout_str), "timeout %d ", cfg->sandbox_timeout);
@@ -162,6 +172,14 @@ static char *tool_execute(const Config *cfg, const char *name, cJSON *arguments)
         char net_str[32] = "";
         if (cfg->sandbox_net) {
             snprintf(net_str, sizeof(net_str), "--unshare-net ");
+        }
+        char skills_bind[MAX_PATH + 64] = "";
+        if (cfg->skills_dir[0]) {
+            mkdirp(cfg->skills_dir);
+            struct stat sb;
+            if (stat(cfg->skills_dir, &sb) == 0 && S_ISDIR(sb.st_mode))
+                snprintf(skills_bind, sizeof(skills_bind),
+                    "--ro-bind %s /skills ", cfg->skills_dir);
         }
         snprintf(cmd_buf, sizeof(cmd_buf),
             "%s bwrap "
@@ -174,6 +192,7 @@ static char *tool_execute(const Config *cfg, const char *name, cJSON *arguments)
             "--new-session "              // verhindert TIOCSTI-Escape
             "--tmpfs / "                  // leerer Root
             "--bind %s /work "            // aktueller Ordner → /work
+            "%s"                          // system skills read-only (optional)
             "--chdir /work "              // startet im Arbeitsverzeichnis
             "--ro-bind /bin /bin "
             "--ro-bind /usr /usr "
@@ -182,12 +201,12 @@ static char *tool_execute(const Config *cfg, const char *name, cJSON *arguments)
             "--dev /dev "
             "--proc /proc "
             "--tmpfs /tmp "
-            "%s "                         // optional: Netzwerk isolieren (nur localhost)
-            "sh -c '%s 2>&1'",
+            "%s "                         // optional: Netzwerk isolieren
+            "bash /work/.szc_cmd 2>&1",
             timeout_str,
             cwd,
-            net_str,
-            command);
+            skills_bind,
+            net_str);
     } else {
         snprintf(cmd_buf, sizeof(cmd_buf), "%s 2>&1", command);
     }
@@ -201,33 +220,48 @@ static char *tool_execute(const Config *cfg, const char *name, cJSON *arguments)
         total += n; if (total >= MAX_OUTPUT - 1) break;
     }
     out[total] = '\0'; pclose(fp);
+    if (cfg->sandbox_bwrap) {
+        char script_path[PATH_MAX];
+        char cwd2[PATH_MAX];
+        if (getcwd(cwd2, sizeof(cwd2)))
+            { snprintf(script_path, sizeof(script_path), "%s/.szc_cmd", cwd2); unlink(script_path); }
+    }
     return out;
 }
 
-char *agent_build_system_prompt(const char *skills_dir) {
-    size_t cap = 8192;
-    char *prompt = malloc(cap);
-    size_t len = snprintf(prompt, cap,
-        "You are SubZeroClaw, a minimal agentic assistant.\n"
-        "You have one tool: shell. Use it to run any command.\n"
-        "For files, use cat, tee, sed, etc. Be concise. Just do it.\n\n");
-    DIR *d = opendir(skills_dir); if (!d) return prompt;
+static size_t load_skills(char **prompt, size_t len, size_t *cap,
+                          const char *dir, const char *label) {
+    DIR *d = opendir(dir); if (!d) return len;
     struct dirent *entry;
     while ((entry = readdir(d))) {
         size_t nlen = strlen(entry->d_name);
         if (nlen < 4 || strcmp(entry->d_name + nlen - 3, ".md") != 0) continue;
-        char fp[MAX_PATH]; snprintf(fp, MAX_PATH, "%s/%s", skills_dir, entry->d_name);
+        char fp[MAX_PATH]; snprintf(fp, MAX_PATH, "%s/%s", dir, entry->d_name);
         FILE *sf = fopen(fp, "r"); if (!sf) continue;
         fseek(sf, 0, SEEK_END); long sz = ftell(sf); fseek(sf, 0, SEEK_SET);
         char *content = malloc(sz + 1);
         content[fread(content, 1, sz, sf)] = '\0'; fclose(sf);
         size_t clen = strlen(content);
-        while (len + clen + 128 >= cap) { cap *= 2; prompt = realloc(prompt, cap); }
-        len += snprintf(prompt + len, cap - len, "\n--- SKILL: %s ---\n", entry->d_name);
-        memcpy(prompt + len, content, clen); len += clen; prompt[len] = '\0';
+        while (len + clen + 128 >= *cap) { *cap *= 2; *prompt = realloc(*prompt, *cap); }
+        len += snprintf(*prompt + len, *cap - len, "\n--- %s: %s ---\n", label, entry->d_name);
+        memcpy(*prompt + len, content, clen); len += clen; (*prompt)[len] = '\0';
         free(content);
     }
     closedir(d);
+    return len;
+}
+
+char *agent_build_system_prompt(const char *skills_dir, const char *project_skills_dir) {
+    size_t cap = 8192;
+    char *prompt = malloc(cap);
+    size_t len = snprintf(prompt, cap,
+        "You are SubZeroClaw, a minimal agentic assistant.\n"
+        "You have one tool: shell. Use it to run any command.\n"
+        "For files, use cat, tee, sed, etc. Be concise. Just do it.\n"
+        "System skills: /skills/ (read-only). "
+        "Project skills: /work/skills/ (read-write, create and edit freely).\n\n");
+    len = load_skills(&prompt, len, &cap, skills_dir, "SKILL");
+    len = load_skills(&prompt, len, &cap, project_skills_dir, "PROJECT SKILL");
     return prompt;
 }
 
@@ -388,7 +422,12 @@ static int process_tool_calls(const Config *cfg, cJSON *tool_calls, cJSON *msgs,
 }
 
 static int agent_run(const Config *cfg, const char *task, FILE *log) {
-    char *system_prompt = agent_build_system_prompt(cfg->skills_dir);
+    char project_skills[MAX_PATH] = "";
+    char cwd[PATH_MAX];
+    if (getcwd(cwd, sizeof(cwd)))
+        snprintf(project_skills, MAX_PATH, "%s/skills", cwd);
+    if (project_skills[0]) mkdirp(project_skills);
+    char *system_prompt = agent_build_system_prompt(cfg->skills_dir, project_skills);
     cJSON *msgs = cJSON_CreateArray();
     cJSON_AddItemToArray(msgs, make_msg("system", system_prompt));
     free(system_prompt);
@@ -430,15 +469,10 @@ int main(int argc, char **argv) {
 
     mkdirp(cfg.skills_dir); mkdirp(cfg.log_dir);
 
-    char session_id[17];
-    int fd = open("/dev/urandom", O_RDONLY);
-    if (fd >= 0) {
-        unsigned char buf[8]; read(fd, buf, 8); close(fd);
-        snprintf(session_id, sizeof(session_id), "%02x%02x%02x%02x%02x%02x%02x%02x",
-                 buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
-    } else {
-        snprintf(session_id, sizeof(session_id), "%016lx", (unsigned long)time(NULL));
-    }
+    char session_id[32];
+    time_t now = time(NULL);
+    struct tm *tm = localtime(&now);
+    strftime(session_id, sizeof(session_id), "%Y%m%dT%H%M%S", tm);
 
     char log_path[MAX_PATH];
     snprintf(log_path, MAX_PATH, "%s/%s.txt", cfg.log_dir, session_id);
@@ -452,14 +486,13 @@ int main(int argc, char **argv) {
         }
         agent_run(&cfg, task, log);
     } else {
-        char line[8192];
         while (1) {
-            printf("> "); fflush(stdout);
-            if (!fgets(line, sizeof(line), stdin)) break;
-            size_t len = strlen(line);
-            while (len && line[len-1] == '\n') line[--len] = '\0';
-            if (!strcmp(line, "/quit") || !strcmp(line, "/exit")) break;
+            char *line = readline("> ");
+            if (!line) break;
+            if (!strcmp(line, "/quit") || !strcmp(line, "/exit")) { free(line); break; }
+            if (line[0]) add_history(line);
             agent_run(&cfg, line, log);
+            free(line);
         }
     }
 

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -1,13 +1,16 @@
-/* subzeroclaw.c — skill-driven agentic runtime */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <dirent.h>
+#include <time.h>
+#include <fcntl.h>
 #include <cjson/cJSON.h>
+
+// NEW: Für getcwd (Sandbox CWD)
+#include <limits.h>   // PATH_MAX
 
 #define MAX_PATH   512
 #define MAX_VALUE  1024
@@ -17,6 +20,10 @@ typedef struct {
     char api_key[MAX_VALUE], model[MAX_VALUE], endpoint[MAX_VALUE];
     char skills_dir[MAX_PATH], log_dir[MAX_PATH];
     int  max_turns, max_messages;
+    // NEW: Sandbox-Optionen
+    int sandbox_bwrap;      // 1 = Bubblewrap aktiv (default)
+    int sandbox_net;        // 1 = Netzwerk isolieren (nur localhost, default)
+    int sandbox_timeout;    // Timeout in Sekunden (default 60, 0 = deaktiviert)
 } Config;
 
 static void config_parse_line(Config *cfg, const char *key, const char *val) {
@@ -27,6 +34,10 @@ static void config_parse_line(Config *cfg, const char *key, const char *val) {
     else if (!strcmp(key, "log_dir"))      snprintf(cfg->log_dir,    MAX_PATH,  "%s", val);
     else if (!strcmp(key, "max_turns"))    cfg->max_turns    = atoi(val);
     else if (!strcmp(key, "max_messages")) cfg->max_messages = atoi(val);
+    // NEW: Sandbox-Keys parsen
+    else if (!strcmp(key, "sandbox_bwrap"))   cfg->sandbox_bwrap   = atoi(val);
+    else if (!strcmp(key, "sandbox_net"))     cfg->sandbox_net     = atoi(val);
+    else if (!strcmp(key, "sandbox_timeout")) cfg->sandbox_timeout = atoi(val);
 }
 
 int config_load(Config *cfg) {
@@ -38,6 +49,10 @@ int config_load(Config *cfg) {
     snprintf(cfg->skills_dir, MAX_PATH,  "%s/.subzeroclaw/skills", home);
     snprintf(cfg->log_dir,    MAX_PATH,  "%s/.subzeroclaw/logs", home);
     cfg->max_turns = 200; cfg->max_messages = 40;
+    // NEW: Sandbox-Defaults
+    cfg->sandbox_bwrap   = 1;  // Aktiv
+    cfg->sandbox_net     = 1;  // Netzwerk isolieren (nur localhost)
+    cfg->sandbox_timeout = 60; // 60 Sekunden pro Befehl
 
     char path[MAX_PATH];
     snprintf(path, MAX_PATH, "%s/.subzeroclaw/config", home);
@@ -63,6 +78,10 @@ int config_load(Config *cfg) {
     if ((v = getenv("SUBZEROCLAW_API_KEY")))  snprintf(cfg->api_key,  MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_MODEL")))    snprintf(cfg->model,    MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_ENDPOINT"))) snprintf(cfg->endpoint, MAX_VALUE, "%s", v);
+    // NEW: Env-Vars für Sandbox
+    if ((v = getenv("SUBZEROCLAW_SANDBOX_BWRAP")))   cfg->sandbox_bwrap   = atoi(v);
+    if ((v = getenv("SUBZEROCLAW_SANDBOX_NET")))     cfg->sandbox_net     = atoi(v);
+    if ((v = getenv("SUBZEROCLAW_SANDBOX_TIMEOUT"))) cfg->sandbox_timeout = atoi(v);
     if (!cfg->api_key[0]) { fprintf(stderr, "error: no api_key\n"); return -1; }
     return 0;
 }
@@ -123,18 +142,59 @@ static const char TOOLS_JSON[] =
     "\"parameters\":{\"type\":\"object\","
     "\"properties\":{\"command\":{\"type\":\"string\"}},\"required\":[\"command\"]}}}]";
 
-char *tool_execute(const char *name, const char *args_json) {
-    if (strcmp(name, "shell")) return strdup("error: unknown tool");
-    cJSON *args = cJSON_Parse(args_json);
-    cJSON *cmd_item = args ? cJSON_GetObjectItem(args, "command") : NULL;
-    const char *cmd = (cmd_item && cJSON_IsString(cmd_item)) ? cmd_item->valuestring : NULL;
-    if (!cmd) { if (args) cJSON_Delete(args); return strdup("error: missing 'command'"); }
-    size_t len = strlen(cmd);
-    char *full = malloc(len + 8);
-    memcpy(full, cmd, len); memcpy(full + len, " 2>&1", 6);
-    if (args) cJSON_Delete(args);
-    FILE *fp = popen(full, "r"); free(full);
-    if (!fp) return strdup("error: popen failed");
+static char *tool_execute(const Config *cfg, const char *name, cJSON *arguments) {
+    if (strcmp(name, "shell") != 0) return NULL;
+    cJSON *command_json = cJSON_GetObjectItem(arguments, "command");
+    if (!command_json || !cJSON_IsString(command_json)) return strdup("error: missing 'command'");
+    const char *command = command_json->valuestring;
+
+    // NEW: Sandbox mit Bubblewrap + Timeout + optional localhost-only
+    char cmd_buf[8192];
+    if (cfg->sandbox_bwrap) {
+        char cwd[PATH_MAX];
+        if (getcwd(cwd, sizeof(cwd)) == NULL) {
+            return strdup("Failed to get current working directory for sandbox.");
+        }
+        char timeout_str[32] = "";
+        if (cfg->sandbox_timeout > 0) {
+            snprintf(timeout_str, sizeof(timeout_str), "timeout %d ", cfg->sandbox_timeout);
+        }
+        char net_str[32] = "";
+        if (cfg->sandbox_net) {
+            snprintf(net_str, sizeof(net_str), "--unshare-net ");
+        }
+        snprintf(cmd_buf, sizeof(cmd_buf),
+            "%s bwrap "
+            "--unshare-user-try "
+            "--unshare-pid "
+            "--unshare-ipc "
+            "--unshare-uts "
+            "--unshare-cgroup-try "
+            "--die-with-parent "
+            "--new-session "              // verhindert TIOCSTI-Escape
+            "--tmpfs / "                  // leerer Root
+            "--bind %s /work "            // aktueller Ordner → /work
+            "--chdir /work "              // startet im Arbeitsverzeichnis
+            "--ro-bind /bin /bin "
+            "--ro-bind /usr /usr "
+            "--ro-bind /lib /lib "
+            "--ro-bind /lib64 /lib64 "
+            "--dev /dev "
+            "--proc /proc "
+            "--tmpfs /tmp "
+            "%s "                         // optional: Netzwerk isolieren (nur localhost)
+            "sh -c '%s 2>&1'",
+            timeout_str,
+            cwd,
+            net_str,
+            command);
+    } else {
+        snprintf(cmd_buf, sizeof(cmd_buf), "%s 2>&1", command);
+    }
+
+    FILE *fp = popen(cmd_buf, "r");
+    if (!fp) return strdup("Failed to start bubblewrap sandbox or command.");
+
     char *out = malloc(MAX_OUTPUT);
     size_t total = 0, n;
     while ((n = fread(out + total, 1, MAX_OUTPUT - total - 1, fp)) > 0) {
@@ -231,7 +291,6 @@ static int compact_messages(const Config *cfg, cJSON *msgs, FILE *log) {
     fprintf(stderr, "[compact] %d msgs, summarizing\n", total);
     log_write(log, "SYS", "compacting context");
 
-    /* build text digest — keep user/assistant in full, trim only tool outputs */
     size_t cap = 512000, len = 0;
     char *convo = malloc(cap);
     convo[0] = '\0';
@@ -243,157 +302,166 @@ static int compact_messages(const Config *cfg, cJSON *msgs, FILE *log) {
         if (!role || !cJSON_IsString(role) || !ct || !cJSON_IsString(ct)) continue;
         const char *r = role->valuestring, *c = ct->valuestring;
         size_t clen = strlen(c);
-        if (!strcmp(r, "tool") && clen > 2000) {
-            /* tool outputs: first 1000 + ... + last 1000 */
-            len += snprintf(convo + len, cap - len, "tool: %.*s\n...[%zu bytes trimmed]...\n%s\n",
-                1000, c, clen - 2000, c + clen - 1000);
+        if (strcmp(r, "tool") == 0 && clen > 2000) {
+            // Trim long tool outputs
+            len += snprintf(convo + len, cap - len, "[%s] ", r);
+            if (clen > 1000) {
+                memcpy(convo + len, c, 1000);
+                len += 1000;
+                len += snprintf(convo + len, cap - len, "... [trimmed] ...\n");
+            } else {
+                len += snprintf(convo + len, cap - len, "%s\n", c);
+            }
         } else {
-            len += snprintf(convo + len, cap - len, "%s: %s\n", r, c);
+            len += snprintf(convo + len, cap - len, "[%s] %s\n", r, c);
         }
     }
-    size_t plen = len + 128;
-    char *prompt = malloc(plen);
-    snprintf(prompt, plen, "Summarize this conversation. Keep all facts, file paths, "
-        "commands, and decisions. Be concise.\n\n%s", convo);
+
+    const char *summary_prompt = "Summarize this conversation. Keep all facts, details, and key points. Be concise but complete.";
+    cJSON *sum_msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(sum_msgs, make_msg("system", summary_prompt));
+    cJSON_AddItemToArray(sum_msgs, make_msg("user", convo));
     free(convo);
 
-    cJSON *sm = cJSON_CreateArray();
-    cJSON_AddItemToArray(sm, make_msg("user", prompt)); free(prompt);
-    char *rj = build_request(cfg, sm, NULL);
-    char *rb = http_post(cfg->endpoint, cfg->api_key, rj);
-    free(rj); cJSON_Delete(sm);
-    if (!rb) return -1;
+    char *req = build_request(cfg, sum_msgs, NULL);
+    cJSON_Delete(sum_msgs);
+    char *resp_body = http_post(cfg->endpoint, cfg->api_key, req);
+    free(req);
+    if (!resp_body) return -1;
 
     Response resp;
-    if (parse_response(rb, &resp) != 0 || !resp.text) { free(rb); response_free(&resp); return -1; }
-    char *summary = strdup(resp.text); free(rb); response_free(&resp);
-    log_write(log, "COMPACT", summary);
-
-    /* keep last ~10 msgs, but skip orphaned tool msgs at the boundary
-       (their tool_call_ids reference deleted assistant msgs → API rejects) */
-    int start = total - 10;
-    if (start < 1) start = 1;
-    while (start < total - 1) {
-        cJSON *r = cJSON_GetObjectItem(cJSON_GetArrayItem(msgs, start), "role");
-        if (!r || strcmp(r->valuestring, "tool") != 0) break;
-        start++;
+    if (parse_response(resp_body, &resp) < 0) {
+        free(resp_body); return -1;
+    }
+    free(resp_body);
+    if (!resp.text) {
+        response_free(&resp); return -1;
     }
 
-    for (int i = start - 1; i >= 1; i--)
-        cJSON_DeleteItemFromArray(msgs, i);
-    cJSON_InsertItemInArray(msgs, 1, make_msg("user", "[Summary of previous context]"));
-    cJSON_InsertItemInArray(msgs, 2, make_msg("assistant", summary));
-    free(summary);
+    // Ersetze alte Nachrichten durch Summary
+    while (cJSON_GetArraySize(msgs) > 10) {  // behalte letzte 10
+        cJSON_DeleteItemFromArray(msgs, 0);
+    }
+    cJSON_InsertItemInArray(msgs, 0, make_msg("assistant", resp.text));
+    cJSON_InsertItemInArray(msgs, 0, make_msg("user", summary_prompt));
+    response_free(&resp);
     return 0;
 }
 
-static void process_tool_calls(cJSON *tool_calls, cJSON *msgs, FILE *log) {
-    cJSON *tc = NULL;
-    cJSON_ArrayForEach(tc, tool_calls) {
-        cJSON *id = cJSON_GetObjectItem(tc, "id");
-        cJSON *fn = cJSON_GetObjectItem(tc, "function");
-        if (!id || !fn) continue;
-        cJSON *name = cJSON_GetObjectItem(fn, "name");
-        cJSON *args = cJSON_GetObjectItem(fn, "arguments");
-        if (!name || !args) continue;
-        log_write(log, "TOOL", name->valuestring);
-        char *result = tool_execute(name->valuestring, args->valuestring);
-        log_write(log, "RES", result ? result : "null");
-        cJSON *tm = cJSON_CreateObject();
-        cJSON_AddStringToObject(tm, "role", "tool");
-        cJSON_AddStringToObject(tm, "tool_call_id", id->valuestring);
-        cJSON_AddStringToObject(tm, "content", result ? result : "error");
-        cJSON_AddItemToArray(msgs, tm);
-        free(result);
+static int process_tool_calls(const Config *cfg, cJSON *tool_calls, cJSON *msgs, FILE *log) {
+    cJSON *call = NULL;
+    cJSON_ArrayForEach(call, tool_calls) {
+        cJSON *func = cJSON_GetObjectItem(call, "function");
+        if (!func) continue;
+        cJSON *name = cJSON_GetObjectItem(func, "name");
+        cJSON *args = cJSON_GetObjectItem(func, "arguments");
+        if (!name || !cJSON_IsString(name) || !args) continue;
+        // NEW: Handle arguments as string (OpenAI format)
+        cJSON *args_parsed = NULL;
+        if (cJSON_IsString(args)) {
+            const char *args_str = args->valuestring;
+            args_parsed = cJSON_Parse(args_str);
+            if (args_parsed) {
+                args = args_parsed;
+            } else {
+                fprintf(stderr, "Failed to parse tool arguments: %s\n", args_str);
+                continue;
+            }
+        } else if (!cJSON_IsObject(args)) {
+            continue;
+        }
+        log_write(log, "TOOL_CALL", name->valuestring);
+        char *result = tool_execute(cfg, name->valuestring, args);
+        if (args_parsed) cJSON_Delete(args_parsed);
+        if (result) {
+            log_write(log, "TOOL_RESULT", result);
+            cJSON *tool_msg = cJSON_CreateObject();
+            cJSON_AddStringToObject(tool_msg, "role", "tool");
+            cJSON_AddStringToObject(tool_msg, "name", name->valuestring);
+            cJSON_AddStringToObject(tool_msg, "content", result);
+            cJSON_AddStringToObject(tool_msg, "tool_call_id", call->child->valuestring);  // id
+            cJSON_AddItemToArray(msgs, tool_msg);
+            free(result);
+        }
     }
+    return 0;
 }
 
-static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
-                     const char *input, FILE *log)
-{
-    cJSON_AddItemToArray(msgs, make_msg("user", input));
-    log_write(log, "USER", input);
+static int agent_run(const Config *cfg, const char *task, FILE *log) {
+    char *system_prompt = agent_build_system_prompt(cfg->skills_dir);
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("system", system_prompt));
+    free(system_prompt);
+    if (task) cJSON_AddItemToArray(msgs, make_msg("user", task));
 
+    cJSON *tools = cJSON_Parse(TOOLS_JSON);
     for (int turn = 1; turn <= cfg->max_turns; turn++) {
-        compact_messages(cfg, msgs, log);
-        char *rj = build_request(cfg, msgs, tools); if (!rj) return -1;
-        fprintf(stderr, "[%d] %s...\n", turn, cfg->model);
-        char *rb = http_post(cfg->endpoint, cfg->api_key, rj); free(rj);
-        if (!rb) return -1;
+        if (compact_messages(cfg, msgs, log) < 0) break;
+
+        char *req = build_request(cfg, msgs, tools);
+        log_write(log, "REQUEST", req);
+        char *resp_body = http_post(cfg->endpoint, cfg->api_key, req);
+        free(req);
+        if (!resp_body) break;
+
         Response resp;
-        if (parse_response(rb, &resp) != 0) { free(rb); return -1; }
-        free(rb);
+        if (parse_response(resp_body, &resp) < 0) { free(resp_body); break; }
+        free(resp_body);
+
+        log_write(log, "RESPONSE", resp.text ? resp.text : "(tool calls)");
         cJSON_AddItemToArray(msgs, resp.msg); resp.msg = NULL;
 
-        if (!strcmp(resp.finish_reason, "stop")) {
-            if (resp.text) { printf("%s\n", resp.text); log_write(log, "ASST", resp.text); }
-            free(resp.finish_reason); return 0;
+        if (strcmp(resp.finish_reason, "stop") == 0) {
+            if (resp.text) printf("%s\n", resp.text);
+            response_free(&resp); break;
+        } else if (strcmp(resp.finish_reason, "tool_calls") == 0) {
+            if (process_tool_calls(cfg, resp.tool_calls, msgs, log) < 0) { response_free(&resp); break; }
         }
-        if (!strcmp(resp.finish_reason, "tool_calls") && resp.tool_calls) {
-            process_tool_calls(resp.tool_calls, msgs, log);
-            free(resp.finish_reason); continue;
-        }
-        if (resp.text) { printf("%s\n", resp.text); log_write(log, "ASST", resp.text); }
-        free(resp.finish_reason); return 0;
+        response_free(&resp);
     }
-    fprintf(stderr, "error: max turns (%d) reached\n", cfg->max_turns);
-    return -1;
+    cJSON_Delete(msgs); cJSON_Delete(tools);
+    return 0;
 }
 
-#ifndef SZC_TEST
 int main(int argc, char **argv) {
-    if (argc > 1 && (!strcmp(argv[1], "--help") || !strcmp(argv[1], "-h"))) {
-        fprintf(stderr, "SubZeroClaw — skill-driven agentic runtime\n"
-            "Usage: subzeroclaw [\"prompt\"]\nConfig: ~/.subzeroclaw/config\n");
-        return 0;
-    }
     Config cfg;
-    if (config_load(&cfg)) return 1;
-    char *sysprompt = agent_build_system_prompt(cfg.skills_dir);
-    if (!sysprompt) return 1;
+    if (config_load(&cfg) < 0) return 1;
 
-    char sid[32] = {0};
-    { FILE *ur = fopen("/dev/urandom", "r");
-      if (ur) { unsigned char b[8];
-          if (fread(b, 1, 8, ur) == 8)
-              snprintf(sid, sizeof(sid), "%02x%02x%02x%02x%02x%02x%02x%02x",
-                  b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]);
-          fclose(ur); }
-      if (!sid[0]) snprintf(sid, sizeof(sid), "%lx%x", (long)time(NULL), getpid()); }
-    mkdirp(cfg.log_dir);
-    char lp[600]; snprintf(lp, sizeof(lp), "%s/%s.txt", cfg.log_dir, sid);
-    FILE *log = fopen(lp, "a");
-    if (log) { time_t now = time(NULL); fprintf(log, "=== %s %s", sid, ctime(&now)); fflush(log); }
+    mkdirp(cfg.skills_dir); mkdirp(cfg.log_dir);
 
-    cJSON *msgs = cJSON_CreateArray();
-    cJSON_AddItemToArray(msgs, make_msg("system", sysprompt));
-    cJSON *tools = cJSON_Parse(TOOLS_JSON);
-    int rc = 0;
-    fprintf(stderr, "subzeroclaw · %s · %s\n", cfg.model, sid);
+    char session_id[17];
+    int fd = open("/dev/urandom", O_RDONLY);
+    if (fd >= 0) {
+        unsigned char buf[8]; read(fd, buf, 8); close(fd);
+        snprintf(session_id, sizeof(session_id), "%02x%02x%02x%02x%02x%02x%02x%02x",
+                 buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
+    } else {
+        snprintf(session_id, sizeof(session_id), "%016lx", (unsigned long)time(NULL));
+    }
+
+    char log_path[MAX_PATH];
+    snprintf(log_path, MAX_PATH, "%s/%s.txt", cfg.log_dir, session_id);
+    FILE *log = fopen(log_path, "w");
+    if (log) fprintf(log, "# Session %s\n", session_id);
 
     if (argc > 1) {
-        char input[4096], *p = input, *end = input + sizeof(input) - 1;
-        for (int i = 1; i < argc && p < end; i++) {
-            if (i > 1) *p++ = ' ';
-            size_t l = strlen(argv[i]), a = end - p; if (l > a) l = a;
-            memcpy(p, argv[i], l); p += l;
+        char task[8192]; task[0] = '\0';
+        for (int i = 1; i < argc; i++) {
+            strcat(task, argv[i]); if (i < argc - 1) strcat(task, " ");
         }
-        *p = '\0';
-        rc = agent_run(&cfg, msgs, tools, input, log);
+        agent_run(&cfg, task, log);
     } else {
-        char input[4096];
-        for (;;) {
+        char line[8192];
+        while (1) {
             printf("> "); fflush(stdout);
-            if (!fgets(input, sizeof(input), stdin)) break;
-            size_t len = strlen(input);
-            while (len && strchr("\n\r", input[len - 1])) input[--len] = '\0';
-            if (!len) continue;
-            if (!strcmp(input, "/quit") || !strcmp(input, "/exit")) break;
-            agent_run(&cfg, msgs, tools, input, log); printf("\n");
+            if (!fgets(line, sizeof(line), stdin)) break;
+            size_t len = strlen(line);
+            while (len && line[len-1] == '\n') line[--len] = '\0';
+            if (!strcmp(line, "/quit") || !strcmp(line, "/exit")) break;
+            agent_run(&cfg, line, log);
         }
     }
-    cJSON_Delete(msgs); cJSON_Delete(tools); free(sysprompt);
+
     if (log) fclose(log);
-    return rc;
+    return 0;
 }
-#endif

--- a/src/test.c
+++ b/src/test.c
@@ -9,11 +9,40 @@ static int tests_failed = 0;
 #define PASS() do { printf("✓\n"); tests_passed++; } while(0)
 #define FAIL(msg) do { printf("✗ %s\n", msg); tests_failed++; } while(0)
 
+/* Helper: Config ohne Sandbox */
+static Config test_cfg(void) {
+    Config cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.sandbox_bwrap = 0;
+    cfg.sandbox_net = 0;
+    cfg.sandbox_timeout = 0;
+    return cfg;
+}
+
+/* Helper: Config mit Sandbox */
+static Config test_cfg_sandbox(void) {
+    Config cfg = test_cfg();
+    cfg.sandbox_bwrap = 1;
+    cfg.sandbox_net = 0;
+    cfg.sandbox_timeout = 30;
+    return cfg;
+}
+
+/* Helper: tool_execute mit JSON-String */
+static char *exec_shell(const Config *cfg, const char *json_args) {
+    cJSON *args = cJSON_Parse(json_args);
+    if (!args) return strdup("error: invalid JSON");
+    char *r = tool_execute(cfg, "shell", args);
+    cJSON_Delete(args);
+    return r;
+}
+
 /* ======== TOOL TESTS ======== */
 
 static void test_shell_echo(void) {
     TEST("shell: echo");
-    char *r = tool_execute("shell", "{\"command\": \"echo hello_subzeroclaw\"}");
+    Config cfg = test_cfg();
+    char *r = exec_shell(&cfg, "{\"command\": \"echo hello_subzeroclaw\"}");
     assert(r);
     if (strstr(r, "hello_subzeroclaw")) PASS();
     else FAIL(r);
@@ -22,7 +51,8 @@ static void test_shell_echo(void) {
 
 static void test_shell_pipe(void) {
     TEST("shell: pipe + grep");
-    char *r = tool_execute("shell", "{\"command\": \"echo abc123def | grep -o '[0-9]\\\\+'\"}");
+    Config cfg = test_cfg();
+    char *r = exec_shell(&cfg, "{\"command\": \"echo abc123def | grep -o '[0-9]\\\\+'\"}");
     assert(r);
     if (strstr(r, "123")) PASS();
     else FAIL(r);
@@ -31,7 +61,8 @@ static void test_shell_pipe(void) {
 
 static void test_shell_stderr(void) {
     TEST("shell: captures stderr");
-    char *r = tool_execute("shell", "{\"command\": \"LC_ALL=C ls /nonexistent_path_xyz\"}");
+    Config cfg = test_cfg();
+    char *r = exec_shell(&cfg, "{\"command\": \"LC_ALL=C ls /nonexistent_path_xyz\"}");
     assert(r);
     if (strstr(r, "No such file") || strstr(r, "cannot access") || strstr(r, "error")) PASS();
     else FAIL(r);
@@ -39,20 +70,85 @@ static void test_shell_stderr(void) {
 }
 
 static void test_unknown_tool(void) {
-    TEST("unknown tool returns error");
-    char *r = tool_execute("teleport", "{\"destination\": \"mars\"}");
+    TEST("unknown tool returns NULL");
+    Config cfg = test_cfg();
+    cJSON *args = cJSON_Parse("{\"destination\": \"mars\"}");
+    char *r = tool_execute(&cfg, "teleport", args);
+    if (r == NULL) PASS();
+    else { FAIL(r); free(r); }
+    cJSON_Delete(args);
+}
+
+static void test_shell_missing_command(void) {
+    TEST("shell: missing command field");
+    Config cfg = test_cfg();
+    char *r = exec_shell(&cfg, "{\"foo\": \"bar\"}");
     assert(r);
-    if (strstr(r, "unknown tool")) PASS();
+    if (strstr(r, "error")) PASS();
     else FAIL(r);
     free(r);
 }
 
-static void test_shell_bad_args(void) {
-    TEST("shell: bad args JSON");
-    char *r = tool_execute("shell", "not json at all");
+/* ======== SANDBOX TESTS ======== */
+
+static void test_sandbox_echo(void) {
+    TEST("sandbox: echo");
+    Config cfg = test_cfg_sandbox();
+    char *r = exec_shell(&cfg, "{\"command\": \"echo sandbox_works\"}");
     assert(r);
-    if (strstr(r, "error")) PASS();
+    if (strstr(r, "sandbox_works")) PASS();
     else FAIL(r);
+    free(r);
+}
+
+static void test_sandbox_workdir(void) {
+    TEST("sandbox: workdir is /work");
+    Config cfg = test_cfg_sandbox();
+    char *r = exec_shell(&cfg, "{\"command\": \"pwd\"}");
+    assert(r);
+    if (strstr(r, "/work")) PASS();
+    else FAIL(r);
+    free(r);
+}
+
+static void test_sandbox_no_home(void) {
+    TEST("sandbox: no /home access");
+    Config cfg = test_cfg_sandbox();
+    char *r = exec_shell(&cfg, "{\"command\": \"ls /home 2>&1 || echo no_home\"}");
+    assert(r);
+    if (strstr(r, "No such file") || strstr(r, "no_home") || strstr(r, "cannot access")) PASS();
+    else FAIL(r);
+    free(r);
+}
+
+static void test_sandbox_has_bin(void) {
+    TEST("sandbox: /bin accessible");
+    Config cfg = test_cfg_sandbox();
+    char *r = exec_shell(&cfg, "{\"command\": \"ls /bin/sh\"}");
+    assert(r);
+    if (strstr(r, "/bin/sh")) PASS();
+    else FAIL(r);
+    free(r);
+}
+
+static void test_sandbox_workdir_files(void) {
+    TEST("sandbox: workdir contains cwd files");
+    Config cfg = test_cfg_sandbox();
+    char *r = exec_shell(&cfg, "{\"command\": \"ls /work/src/subzeroclaw.c\"}");
+    assert(r);
+    if (strstr(r, "subzeroclaw.c")) PASS();
+    else FAIL(r);
+    free(r);
+}
+
+static void test_sandbox_timeout(void) {
+    TEST("sandbox: timeout kills slow cmd");
+    Config cfg = test_cfg_sandbox();
+    cfg.sandbox_timeout = 2;
+    char *r = exec_shell(&cfg, "{\"command\": \"sleep 10\"}");
+    assert(r);
+    /* timeout kills it, output should be empty or contain signal info */
+    PASS();
     free(r);
 }
 
@@ -152,8 +248,8 @@ static void test_parse_garbage(void) {
 
 static void test_full_tool_dispatch(void) {
     TEST("e2e: parse tool_call -> execute -> result");
-    const char *mock_args = "{\"command\": \"echo subzeroclaw_e2e_ok\"}";
-    char *result = tool_execute("shell", mock_args);
+    Config cfg = test_cfg();
+    char *result = exec_shell(&cfg, "{\"command\": \"echo subzeroclaw_e2e_ok\"}");
     assert(result);
 
     cJSON *tool_msg = cJSON_CreateObject();
@@ -187,7 +283,7 @@ static void test_system_prompt(void) {
 
 static void test_skills_loading(void) {
     TEST("skills: loads .md files into prompt");
-    system("mkdir -p /tmp/szc_skills");
+    (void)system("mkdir -p /tmp/szc_skills");
     FILE *f = fopen("/tmp/szc_skills/email.md", "w");
     fprintf(f, "You can use himalaya for email.\n");
     fclose(f);
@@ -197,15 +293,14 @@ static void test_skills_loading(void) {
     if (strstr(p, "himalaya")) PASS();
     else FAIL("skill not loaded");
     free(p);
-    system("rm -rf /tmp/szc_skills");
+    (void)system("rm -rf /tmp/szc_skills");
 }
 
 /* ======== REQUEST BUILDING TESTS ======== */
 
 static void test_build_request(void) {
     TEST("build_request: JSON structure");
-    Config cfg;
-    memset(&cfg, 0, sizeof(cfg));
+    Config cfg = test_cfg();
     snprintf(cfg.model, MAX_VALUE, "test-model");
     cJSON *msgs = cJSON_CreateArray();
     cJSON_AddItemToArray(msgs, make_msg("system", "hello"));
@@ -247,12 +342,16 @@ static void test_config_no_key(void) {
 
 static void test_config_defaults(void) {
     TEST("config: loads with env var");
+    char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
+    setenv("HOME", "/tmp/szc_no_config", 1);
     setenv("SUBZEROCLAW_API_KEY", "sk-test-fake-key", 1);
     Config cfg;
     int rc = config_load(&cfg);
+    if (old_home) { setenv("HOME", old_home, 1); free(old_home); }
+    else unsetenv("HOME");
     if (rc == 0 &&
         strcmp(cfg.api_key, "sk-test-fake-key") == 0 &&
-        strstr(cfg.endpoint, "openrouter.ai"))
+        strlen(cfg.endpoint) > 0)
         PASS();
     else
         FAIL("config mismatch");
@@ -265,20 +364,35 @@ int main(void) {
     printf("\n  SubZeroClaw test suite\n");
     printf("  ═══════════════════════════════════════════\n\n");
 
+    /* tool tests */
     test_shell_echo();
     test_shell_pipe();
     test_shell_stderr();
     test_unknown_tool();
-    test_shell_bad_args();
+    test_shell_missing_command();
+
+    /* sandbox tests */
+    test_sandbox_echo();
+    test_sandbox_workdir();
+    test_sandbox_no_home();
+    test_sandbox_has_bin();
+    test_sandbox_workdir_files();
+    test_sandbox_timeout();
+
+    /* JSON / structure */
     test_tools_definitions();
     test_parse_stop_response();
     test_parse_tool_calls_response();
     test_parse_error_response();
     test_parse_garbage();
+
+    /* e2e + prompt */
     test_build_request();
     test_full_tool_dispatch();
     test_system_prompt();
     test_skills_loading();
+
+    /* config */
     test_config_no_key();
     test_config_defaults();
 

--- a/src/test.c
+++ b/src/test.c
@@ -141,6 +141,21 @@ static void test_sandbox_workdir_files(void) {
     free(r);
 }
 
+static void test_sandbox_create_user_skill(void) {
+    TEST("sandbox: create user skill in /work/skills");
+    Config cfg = test_cfg_sandbox();
+    /* skills/ does not exist yet — mkdir + write + read back */
+    char *r = exec_shell(&cfg, "{\"command\": \"mkdir -p /work/skills && "
+        "cat > /work/skills/test.md << 'SKILL'\\n## Test Skill\\nDo the thing.\\nSKILL\\n"
+        "cat /work/skills/test.md\"}");
+    assert(r);
+    int ok = strstr(r, "Test Skill") && strstr(r, "Do the thing");
+    free(r);
+    /* cleanup on host */
+    (void)system("rm -rf skills");
+    if (ok) PASS(); else FAIL("skill not created or not readable");
+}
+
 static void test_sandbox_timeout(void) {
     TEST("sandbox: timeout kills slow cmd");
     Config cfg = test_cfg_sandbox();
@@ -274,7 +289,7 @@ static void test_full_tool_dispatch(void) {
 
 static void test_system_prompt(void) {
     TEST("system prompt builds without crash");
-    char *p = agent_build_system_prompt("/nonexistent_dir");
+    char *p = agent_build_system_prompt("/nonexistent_dir", "/nonexistent_dir");
     assert(p);
     if (strstr(p, "SubZeroClaw")) PASS();
     else FAIL("missing base prompt");
@@ -288,7 +303,7 @@ static void test_skills_loading(void) {
     fprintf(f, "You can use himalaya for email.\n");
     fclose(f);
 
-    char *p = agent_build_system_prompt("/tmp/szc_skills");
+    char *p = agent_build_system_prompt("/tmp/szc_skills", "/nonexistent_dir");
     assert(p);
     if (strstr(p, "himalaya")) PASS();
     else FAIL("skill not loaded");
@@ -377,6 +392,7 @@ int main(void) {
     test_sandbox_no_home();
     test_sandbox_has_bin();
     test_sandbox_workdir_files();
+    test_sandbox_create_user_skill();
     test_sandbox_timeout();
 
     /* JSON / structure */


### PR DESCRIPTION
# Changelog v0.2.0

All changes from the initial commit (`29b9f68`, 197 lines) to `v0.2.0` (~510 lines).

---

## 1. Removed `read_file` and `write_file` tools — shell-only design

The initial version exposed three tools to the LLM: `shell`, `read_file`, and `write_file`. v0.2.0 removes the two file tools entirely, leaving only `shell`.

**Initial (3 tools):**
```c
static const char TOOLS[]=
    "[{...\"name\":\"shell\",...},{...\"name\":\"read_file\",...},{...\"name\":\"write_file\",...}]";

char *tool_execute(const char *name, const char *aj) {
    cJSON *a = cJSON_Parse(aj);
    if (!strcmp(name,"shell")) { ... }
    else if (!strcmp(name,"read_file")) { ... }
    else if (!strcmp(name,"write_file")) { ... }
}
```

**v0.2.0 (1 tool):**
```c
static const char TOOLS_JSON[] =
    "[{\"type\":\"function\",\"function\":{\"name\":\"shell\","
    "\"description\":\"Run a shell command\","
    "\"parameters\":{...}}}]";

static char *tool_execute(const Config *cfg, const char *name, cJSON *arguments) {
    if (strcmp(name, "shell") != 0) return NULL;
    ...
}
```

The LLM now uses `cat`, `tee`, `sed`, etc. through the shell for file operations. This follows the anti-framework philosophy: the shell is the only integration layer needed.

---

## 2. Bubblewrap sandbox for tool execution

The initial version ran shell commands directly via `popen()` with no isolation. v0.2.0 adds optional sandboxing using [bubblewrap](https://github.com/containers/bubblewrap).

**Initial (no sandbox):**
```c
char *fc = malloc(cl+8);
memcpy(fc, f1->valuestring, cl);
memcpy(fc+cl, " 2>&1", 6);
FILE *fp = popen(fc, "r");
```

**v0.2.0 (bwrap sandbox):**
```c
if (cfg->sandbox_bwrap) {
    // Write command to temp file to avoid quoting issues
    snprintf(script_path, sizeof(script_path), "%s/.szc_cmd", cwd);
    FILE *sf = fopen(script_path, "w");
    fprintf(sf, "%s\n", command);

    snprintf(cmd_buf, sizeof(cmd_buf),
        "%s bwrap "
        "--unshare-user-try --unshare-pid --unshare-ipc "
        "--unshare-uts --unshare-cgroup-try "
        "--die-with-parent --new-session "
        "--tmpfs / "
        "--bind %s /work "         // current dir -> /work
        "--ro-bind /bin /bin "
        "--ro-bind /usr /usr "
        "--ro-bind /lib /lib --ro-bind /lib64 /lib64 "
        "--dev /dev --proc /proc --tmpfs /tmp "
        "%s "                      // optional: --unshare-net
        "bash /work/.szc_cmd 2>&1",
        timeout_str, cwd, skills_bind, net_str);
} else {
    snprintf(cmd_buf, sizeof(cmd_buf), "%s 2>&1", command);
}
```

Three new config options control sandbox behavior:

| Option | Default | Effect |
|--------|---------|--------|
| `sandbox_bwrap` | 1 | Enable bubblewrap isolation |
| `sandbox_net` | 1 | Block external network (localhost only) |
| `sandbox_timeout` | 60 | Kill commands after N seconds |

The sandbox mounts the current directory as `/work`, provides read-only access to system binaries, and optionally isolates networking with `--unshare-net`.

---

## 3. Config struct and parsing refactored for readability

The initial version used cryptic short field names. v0.2.0 uses full descriptive names and adds sandbox fields.

**Initial:**
```c
typedef struct { char key[MV],model[MV],ep[MV],skills[MP],logdir[MP]; int mt,mm,ck; } Cfg;
```

**v0.2.0:**
```c
typedef struct {
    char api_key[MAX_VALUE], model[MAX_VALUE], endpoint[MAX_VALUE];
    char skills_dir[MAX_PATH], log_dir[MAX_PATH];
    int  max_turns, max_messages;
    int sandbox_bwrap;
    int sandbox_net;
    int sandbox_timeout;
} Config;
```

The parser (`config_parse_line`) is now a separate function, and environment variable overrides are added for all sandbox options (`SUBZEROCLAW_SANDBOX_BWRAP`, `SUBZEROCLAW_SANDBOX_NET`, `SUBZEROCLAW_SANDBOX_TIMEOUT`).

---

## 4. Readable code style throughout

The initial version was aggressively compressed into 197 lines. v0.2.0 reformats everything for readability with proper indentation, spacing, and named constants.

**Initial (compressed):**
```c
#define MP 512
#define MV 1024
#define MR (128*1024)

static void logw(FILE *f,const char *r,const char *c){if(!f)return;time_t n=time(0);
    struct tm *t=localtime(&n);char ts[32];strftime(ts,32,"%Y-%m-%d %H:%M:%S",t);
    fprintf(f,"[%s] %s: %s\n",ts,r,c);fflush(f);}
```

**v0.2.0 (readable):**
```c
#define MAX_PATH   512
#define MAX_VALUE  1024
#define MAX_OUTPUT (128 * 1024)

static void log_write(FILE *log, const char *role, const char *content) {
    if (!log) return;
    time_t now = time(NULL);
    struct tm *t = localtime(&now);
    char ts[32]; strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", t);
    fprintf(log, "[%s] %s: %s\n", ts, role, content); fflush(log);
}
```

All functions follow this pattern: `build_req` -> `build_request`, `parse_resp` -> `parse_response`, `compact` -> `compact_messages`, `logw` -> `log_write`, etc.

---

## 5. Secure HTTP posting (API key no longer in command line)

The initial version passed the API key directly in the curl command line, visible in `ps` output:

**Initial:**
```c
snprintf(cmd, 2048, "curl -s -m 120 -H 'Authorization: Bearer %s' "
    "-H 'Content-Type: application/json' -d @/tmp/.szc.json '%s' 2>&1", key, url);
```

**v0.2.0:**
```c
// Write header to temp file — API key never appears in process list
char hdr[MAX_VALUE + 64];
snprintf(hdr, sizeof(hdr), "-H \"Authorization: Bearer %s\"", api_key);
write_temp("hdr", hdr, hdr_path, sizeof(hdr_path));

snprintf(cmd, sizeof(cmd),
    "curl -s -m 120 -K '%s' -H 'Content-Type: application/json' -d @'%s' '%s' 2>&1",
    hdr_path, body_path, url);
```

The `-K` flag tells curl to read the authorization header from a file. Both temp files use `mkstemp()` for unique names (instead of the fixed `/tmp/.szc.json`), preventing race conditions when running multiple instances.

---

## 6. Project-local skills support

The initial version only loaded skills from one global directory (`~/.subzeroclaw/skills/`). v0.2.0 adds a second skill source: the `skills/` directory in the current working directory.

**Initial:**
```c
char *agent_build_system_prompt(const char *dir) {
    // loads skills from one directory only
}
```

**v0.2.0:**
```c
char *agent_build_system_prompt(const char *skills_dir, const char *project_skills_dir) {
    ...
    len = load_skills(&prompt, len, &cap, skills_dir, "SKILL");
    len = load_skills(&prompt, len, &cap, project_skills_dir, "PROJECT SKILL");
    return prompt;
}
```

The `load_skills` function is extracted as a reusable helper that scans a directory for `.md` files and appends them to the system prompt. Global skills are labeled `SKILL`, project-local ones `PROJECT SKILL`.

---

## 7. Tool argument parsing handles both string and object formats

Some LLM APIs return tool call arguments as a JSON string (double-encoded), others as a parsed JSON object. The initial version only handled string arguments. v0.2.0 handles both.

**v0.2.0:**
```c
static int process_tool_calls(const Config *cfg, cJSON *tool_calls, cJSON *msgs, FILE *log) {
    ...
    cJSON *args_parsed = NULL;
    if (cJSON_IsString(args)) {
        args_parsed = cJSON_Parse(args->valuestring);
        if (args_parsed) args = args_parsed;
    } else if (!cJSON_IsObject(args)) {
        continue;
    }
    char *result = tool_execute(cfg, name->valuestring, args);
    if (args_parsed) cJSON_Delete(args_parsed);
    ...
}
```

This makes SubZeroClaw compatible with more API providers (OpenRouter, OpenAI, xAI, etc.).

---

## 8. Improved context compaction

The initial compaction used a simple boundary-based approach that kept the last N messages and discarded the rest. v0.2.0 sends old messages to the LLM for summarization with trimming of long tool outputs.

**Initial:**
```c
static int compact(const Cfg *c, cJSON *msgs, FILE *log) {
    int bnd = tot - c->ck;
    // collect messages 1..bnd into text, delete them
    // insert summary at position 1
}
```

**v0.2.0:**
```c
static int compact_messages(const Config *cfg, cJSON *msgs, FILE *log) {
    // Trim long tool outputs in the summary input
    if (strcmp(r, "tool") == 0 && clen > 2000) {
        memcpy(convo + len, c, 1000);
        len += snprintf(convo + len, cap - len, "... [trimmed] ...\n");
    }
    // Keep last 10 messages, summarize the rest
    while (cJSON_GetArraySize(msgs) > 10) {
        cJSON_DeleteItemFromArray(msgs, 0);
    }
    cJSON_InsertItemInArray(msgs, 0, make_msg("assistant", resp.text));
    cJSON_InsertItemInArray(msgs, 0, make_msg("user", summary_prompt));
}
```

Tool outputs longer than 2000 characters are truncated to 1000 before being sent for summarization, reducing token usage.

---

## 9. Readline integration for interactive mode

The initial version used raw `fgets()` for interactive input. v0.2.0 uses GNU readline for line editing, history, and arrow key navigation.

**Initial:**
```c
printf("> "); fflush(stdout);
if (!fgets(in, 4096, stdin)) break;
```

**v0.2.0:**
```c
#include <readline/readline.h>
#include <readline/history.h>
...
char *line = readline("> ");
if (!line) break;
if (line[0]) add_history(line);
agent_run(&cfg, line, log);
free(line);
```

This adds proper terminal line editing (Ctrl-A, Ctrl-E, backspace, arrow keys) and command history (up/down arrows) to the interactive REPL.

---

## 10. Timestamped session IDs

The initial version generated random hex session IDs from `/dev/urandom`. v0.2.0 uses human-readable timestamps.

**Initial:**
```c
FILE *r = fopen("/dev/urandom","r");
unsigned char b[8];
fread(b, 1, 8, r);
snprintf(sid, 32, "%02x%02x%02x%02x%02x%02x%02x%02x", b[0],...);
```

**v0.2.0:**
```c
time_t now = time(NULL);
struct tm *tm = localtime(&now);
strftime(session_id, sizeof(session_id), "%Y%m%dT%H%M%S", tm);
```

Log files are now named like `20260222T153001.txt` instead of `f850c58ddd4ae72a.txt`, making them easy to find by date.

---

## 11. `--version` flag with license info

**v0.2.0:**
```c
if (argc == 2 && (!strcmp(argv[1], "--version") || !strcmp(argv[1], "-v"))) {
    printf("subzeroclaw %s\n"
           "Copyright (c) 2025-2026 SubZeroClaw contributors\n"
           "License MIT: https://opensource.org/licenses/MIT\n"
           "This is free software: you are free to change and redistribute it.\n"
           "There is NO WARRANTY, to the extent permitted by law.\n",
           SZC_VERSION);
    return 0;
}
```

---

## 12. Agent loop restructured

The initial version passed messages and tools arrays into `agent_run` from `main()`. v0.2.0 creates and manages them internally, keeping the public interface simpler.

**Initial:**
```c
static int agent_run(const Cfg *c, cJSON *msgs, cJSON *tools, const char *in, FILE *log) {
    compact(c, msgs, log);
    cJSON_AddItemToArray(msgs, um);
    for (int t = 0; ++t <= c->mt; ) { ... }
}

// in main():
cJSON *msgs = cJSON_CreateArray();
cJSON *tools = cJSON_Parse(TOOLS);
agent_run(&cfg, msgs, tools, in, log);
```

**v0.2.0:**
```c
static int agent_run(const Config *cfg, const char *task, FILE *log) {
    char *system_prompt = agent_build_system_prompt(cfg->skills_dir, project_skills);
    cJSON *msgs = cJSON_CreateArray();
    cJSON_AddItemToArray(msgs, make_msg("system", system_prompt));
    cJSON *tools = cJSON_Parse(TOOLS_JSON);
    for (int turn = 1; turn <= cfg->max_turns; turn++) { ... }
    cJSON_Delete(msgs); cJSON_Delete(tools);
    return 0;
}

// in main():
agent_run(&cfg, task, log);
```

Each call to `agent_run` now creates a fresh message array, which means context does not carry between separate invocations in interactive mode. This is a deliberate simplification.

---

## 13. Symlink replaced with real header wrapper

The vendored `src/cjson/cJSON.h` was a symlink to `../cJSON.h`. v0.2.0 replaces it with a real file containing just an include directive, which is more portable across filesystems and archives.

**Initial:** symlink `src/cjson/cJSON.h -> ../cJSON.h`

**v0.2.0:**
```c
/* Vendored cJSON wrapper */
#include "../cJSON.h"
```

---

## 14. Makefile links readline

```makefile
# Before:
LDFLAGS = -lm

# After:
LDFLAGS = -lm -lreadline
```

---

## 15. Test suite expanded (14 -> 23 tests)

New tests added for:
- Sandbox execution (echo, workdir, no /home access, /bin access, workdir files, user skill creation, timeout)
- Error handling (unknown tool returns NULL, missing command field, API error responses, garbage JSON input)
- Request building (`build_request` structure validation)
- Config validation (failure without API key)

All tests updated to use the new `Config`-based `tool_execute` signature and the extracted `parse_response`/`build_request` functions.

---

## 16. Supporting files added

- **`.env.example`** — template for environment variable setup
- **`CONTRIBUTING.md`** — contribution guidelines explaining the anti-framework philosophy
- **`.gitignore`** — expanded with editor files, build artifacts, macOS metadata
- **`config.example`** — updated with sandbox options and new default model
- **`szc-logo.png`** — project logo
- **`README.md`** — rewritten with sandbox docs, updated stats, philosophy section
