### PR TITLE
Always send max_tokens in chat completion requests

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -202,6 +202,11 @@ static void response_free(Response *r) {
 static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
     cJSON *req = cJSON_CreateObject();
     cJSON_AddStringToObject(req, "model", cfg->model);
+    /* max_tokens is optional in the OpenAI spec, but some OpenAI-compatible
+       routers (e.g. the genlayer llm-policy shim behind router.ygr.ai) reject
+       requests that omit it with "no_candidates"/"exhausted". Sending an
+       explicit ceiling is also sane hardening against runaway generations. */
+    cJSON_AddNumberToObject(req, "max_tokens", 4096);
     cJSON_AddItemReferenceToObject(req, "messages", msgs);
     if (tools) cJSON_AddItemReferenceToObject(req, "tools", tools);
     char *json = cJSON_PrintUnformatted(req);


### PR DESCRIPTION
## What

`build_request()` now always sets `max_tokens` (4096) on the chat completion payload.

## Why

`max_tokens` is *optional* in the OpenAI spec, so omitting it is spec-correct — but some OpenAI-compatible routers reject requests that leave it out. Concretely, the genlayer **llm-policy** shim behind `router.ygr.ai` returns `no_candidates` / `exhausted` when `max_tokens` is absent, so the agent loop never receives a completion and silently stalls.

Sending an explicit ceiling fixes that and is also reasonable hardening against runaway generations.

## Notes

- Root cause is arguably router-side (it requires an optional field); a parallel fix is going to llm-policy to default `max_tokens` when absent. This client-side change is worthwhile regardless.
- One line, mirrors the adjacent `cJSON_Add*` calls in `build_request()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)