### PR TITLE
build_request: always send max_tokens (router compatibility)

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -202,6 +202,9 @@ static void response_free(Response *r) {
 static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
     cJSON *req = cJSON_CreateObject();
     cJSON_AddStringToObject(req, "model", cfg->model);
+    /* Some routers (e.g. the ygr llm-router shim) REQUIRE max_tokens and reject
+       requests without it ("exhausted"/"no_candidates"). Always send one. */
+    cJSON_AddNumberToObject(req, "max_tokens", 4096);
     cJSON_AddItemReferenceToObject(req, "messages", msgs);
     if (tools) cJSON_AddItemReferenceToObject(req, "tools", tools);
     char *json = cJSON_PrintUnformatted(req);


### PR DESCRIPTION
## What

`build_request` now always adds `max_tokens` (4096) to the chat-completions request body.

## Why

Some OpenAI-compatible routers — specifically the **ygr llm-router** shim that Wingston runs behind — **require** `max_tokens` and reject any request without it with `exhausted` / `no_candidates`. Lenient upstreams ignore an explicit `max_tokens`, so sending one always is safe and makes the same build work behind both a strict router and a permissive provider.

This has been running as a local patch in the Wingston deployment; upstreaming it so the vendored submodule no longer carries an uncommitted change.

## Change
```c
cJSON_AddStringToObject(req, "model", cfg->model);
+/* Some routers (e.g. the ygr llm-router shim) REQUIRE max_tokens and reject
+   requests without it ("exhausted"/"no_candidates"). Always send one. */
+cJSON_AddNumberToObject(req, "max_tokens", 4096);
 cJSON_AddItemReferenceToObject(req, "messages", msgs);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API request compatibility by ensuring required parameters are consistently included in chat-completions requests, preventing rejections from certain routers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->