### PR TITLE
Preserve multi-line turns over piped stdin (one line = one turn)

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -380,6 +380,22 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
     return -1;
 }
 
+/* One stdin line = one turn. A driving program (non-tty stdin) sends a turn as a
+   single line with newlines escaped (\\ and \n) so a multi-line message stays one
+   turn instead of fanning out into one turn per line. Decode them back here, in
+   place. Unknown "\x" is kept verbatim so stray backslashes survive. */
+void unescape_turn(char *s) {
+    char *r = s, *w = s;
+    while (*r) {
+        if (*r == '\\' && r[1]) {
+            if (r[1] == 'n')  { *w++ = '\n'; r += 2; continue; }
+            if (r[1] == '\\') { *w++ = '\\'; r += 2; continue; }
+        }
+        *w++ = *r++;
+    }
+    *w = '\0';
+}
+
 #ifndef SZC_TEST
 /* Grow-as-needed stdin reader. Replaces fgets()+4KB buffer, which
    silently truncated long pasted prompts. */
@@ -442,10 +458,15 @@ int main(int argc, char **argv) {
         *p = '\0';
         rc = agent_run(&cfg, msgs, tools, input, log);
     } else {
+        /* Interactive (tty) stdin is left verbatim so a human can type literal
+           backslashes/code; a driving program (pipe/FIFO) speaks the escaped
+           one-line-per-turn protocol, which we decode (see unescape_turn). */
+        int piped = !isatty(STDIN_FILENO);
         for (;;) {
             printf("> "); fflush(stdout);
             char *input = read_line();
             if (!input) break;
+            if (piped) unescape_turn(input);
             if (!input[0]) { free(input); continue; }
             if (!strcmp(input, "/quit") || !strcmp(input, "/exit")) {
                 free(input); break;

--- a/src/test.c
+++ b/src/test.c
@@ -84,6 +84,50 @@ static void test_shell_exit_code_fail(void) {
     free(r);
 }
 
+/* ======== STDIN TURN DECODING TESTS ======== */
+
+/* The orchestrator escapes each turn so one logical message is one physical
+   stdin line (backslash -> "\\", newline -> "\n"); we decode it back here.
+   Regression guard for the restart-flood bug where a multi-line rehydration
+   preamble fanned out into one LLM turn (and one reply) per line. */
+static void test_unescape_newline_one_turn(void) {
+    TEST("unescape_turn: \\n decodes to real newlines");
+    char buf[256];
+    /* wire form: literal backslash-n between the lines (one physical line) */
+    strcpy(buf, "[From orchestrator] line1\\nline2\\nline3");
+    unescape_turn(buf);
+    if (strcmp(buf, "[From orchestrator] line1\nline2\nline3") == 0) PASS();
+    else FAIL(buf);
+}
+
+static void test_unescape_literal_backslash(void) {
+    TEST("unescape_turn: \\\\ preserves a real backslash");
+    char buf[256];
+    /* wire form for user-typed "a\nb" (backslash, n) -> "a\\nb" on the wire */
+    strcpy(buf, "a\\\\nb");
+    unescape_turn(buf);
+    if (strcmp(buf, "a\\nb") == 0) PASS();   /* a, backslash, n, b — NOT a newline */
+    else FAIL(buf);
+}
+
+static void test_unescape_no_escapes(void) {
+    TEST("unescape_turn: plain text unchanged");
+    char buf[256];
+    strcpy(buf, "[From orchestrator] hello, what's live?");
+    unescape_turn(buf);
+    if (strcmp(buf, "[From orchestrator] hello, what's live?") == 0) PASS();
+    else FAIL(buf);
+}
+
+static void test_unescape_trailing_backslash(void) {
+    TEST("unescape_turn: lone trailing backslash kept");
+    char buf[256];
+    strcpy(buf, "ends with a backslash\\");
+    unescape_turn(buf);
+    if (strcmp(buf, "ends with a backslash\\") == 0) PASS();
+    else FAIL(buf);
+}
+
 /* ======== JSON / TOOLS DEFINITION TESTS ======== */
 
 static void test_tools_definitions(void) {
@@ -301,6 +345,10 @@ int main(void) {
     test_shell_heredoc();
     test_shell_exit_code_ok();
     test_shell_exit_code_fail();
+    test_unescape_newline_one_turn();
+    test_unescape_literal_backslash();
+    test_unescape_no_escapes();
+    test_unescape_trailing_backslash();
     test_tools_definitions();
     test_parse_stop_response();
     test_parse_tool_calls_response();


### PR DESCRIPTION
## Problem

subzeroclaw's REPL reads stdin line-by-line and runs a full agentic turn per line. That's correct for a human typing at the `>` prompt, but it makes the stdin protocol unable to carry a **multi-line message**: any driver that pipes in a turn containing newlines — a code block, a JSON payload, a multi-paragraph instruction, injected conversation history — has that single turn silently split into N turns, each triggering its own LLM call and reply.

This is not hypothetical: the bundled `szc-wrapper` (and any orchestrator feeding stdin) hits it the moment a prompt spans more than one line. In a swarm deployment it manifested as a reply *flood* — a multi-line context preamble fanned out into dozens of replies, one per line.

## Fix

Define the piped-stdin protocol explicitly: a turn is one physical line with newlines escaped (`\` → `\\`, `\n` → `\n`); subzeroclaw decodes them back with `unescape_turn` before running the turn.

Gated on `!isatty(STDIN_FILENO)`:
- **Interactive use is unchanged** — a human at the TTY still gets verbatim input (literal backslashes / pasted code untouched).
- **Programmatic use is fixed** — any driver piping/FIFO-feeding subzeroclaw can send a multi-line turn as one turn.

Backward compatible: single-line turns contain no escapes, so decoding is a no-op. Unknown escapes (`\t`, `\x…`) pass through verbatim. Decode is in place (output never longer than input).

## Why this belongs in subzeroclaw, not the consumer

The "one line = one turn" boundary is subzeroclaw's own protocol — only subzeroclaw can know where a turn ends. Every orchestrator that drives it over a pipe needs multi-line turns to survive, so the decode half has to live here. The matching escape half lives in the driver.

## Tests

`make test` (via `src/test.c`) gains four cases for `unescape_turn`: real newline → newlines, literal backslash preserved (so a user-typed `a\nb` round-trips, not becoming a newline), plain text untouched, and a lone trailing backslash kept. 23 passed, 0 failed; main binary compiles clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced stdin input handling to properly decode escape sequences when data comes from non-interactive sources such as pipes and FIFOs. The application now correctly translates encoded newlines and escaped backslashes while preserving other characters.

* **Tests**
  * Added unit tests to validate escape sequence decoding, including handling of newlines, literal backslashes, unescaped sequences, and trailing backslashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->