### PR TITLE
Frame piped stdin turns by NUL delimiter (replaces the #6 escaping scheme)

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -380,31 +380,21 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
     return -1;
 }
 
-/* One stdin line = one turn. A driving program (non-tty stdin) sends a turn as a
-   single line with newlines escaped (\\ and \n) so a multi-line message stays one
-   turn instead of fanning out into one turn per line. Decode them back here, in
-   place. Unknown "\x" is kept verbatim so stray backslashes survive. */
-void unescape_turn(char *s) {
-    char *r = s, *w = s;
-    while (*r) {
-        if (*r == '\\' && r[1]) {
-            if (r[1] == 'n')  { *w++ = '\n'; r += 2; continue; }
-            if (r[1] == '\\') { *w++ = '\\'; r += 2; continue; }
-        }
-        *w++ = *r++;
-    }
-    *w = '\0';
-}
+/* Read one turn from f, terminated by `delim`. Grows as needed (replaces an
+   fgets()+4KB buffer that silently truncated long pasted prompts). Returns NULL
+   at EOF with no bytes read.
 
-#ifndef SZC_TEST
-/* Grow-as-needed stdin reader. Replaces fgets()+4KB buffer, which
-   silently truncated long pasted prompts. */
-static char *read_line(void) {
+   The delimiter frames turns *without* touching their content: a human at a tty
+   uses '\n' (one typed line = one turn); a driving program (non-tty stdin) uses
+   '\0', which a turn — being text — can never contain, so a multi-line message
+   survives verbatim as a single turn instead of fanning out into one turn (and
+   one LLM call) per line. No escaping, no reinterpretation of backslashes. */
+static char *read_turn(FILE *f, int delim) {
     size_t cap = 65536, len = 0;
     char *buf = malloc(cap);
     if (!buf) return NULL;
     int c;
-    while ((c = fgetc(stdin)) != EOF && c != '\n') {
+    while ((c = fgetc(f)) != EOF && c != delim) {
         if (len + 1 >= cap) {
             cap *= 2;
             char *nb = realloc(buf, cap);
@@ -418,6 +408,7 @@ static char *read_line(void) {
     return buf;
 }
 
+#ifndef SZC_TEST
 int main(int argc, char **argv) {
     if (argc > 1 && (!strcmp(argv[1], "--help") || !strcmp(argv[1], "-h"))) {
         fprintf(stderr, "SubZeroClaw — skill-driven agentic runtime\n"
@@ -458,15 +449,14 @@ int main(int argc, char **argv) {
         *p = '\0';
         rc = agent_run(&cfg, msgs, tools, input, log);
     } else {
-        /* Interactive (tty) stdin is left verbatim so a human can type literal
-           backslashes/code; a driving program (pipe/FIFO) speaks the escaped
-           one-line-per-turn protocol, which we decode (see unescape_turn). */
-        int piped = !isatty(STDIN_FILENO);
+        /* A human at a tty ends a turn with Enter ('\n'); a driving program
+           (pipe/FIFO) ends each turn with a NUL byte, letting one turn carry
+           newlines verbatim instead of fanning out per line (see read_turn). */
+        int delim = isatty(STDIN_FILENO) ? '\n' : '\0';
         for (;;) {
             printf("> "); fflush(stdout);
-            char *input = read_line();
+            char *input = read_turn(stdin, delim);
             if (!input) break;
-            if (piped) unescape_turn(input);
             if (!input[0]) { free(input); continue; }
             if (!strcmp(input, "/quit") || !strcmp(input, "/exit")) {
                 free(input); break;

--- a/src/test.c
+++ b/src/test.c
@@ -84,48 +84,52 @@ static void test_shell_exit_code_fail(void) {
     free(r);
 }
 
-/* ======== STDIN TURN DECODING TESTS ======== */
+/* ======== STDIN TURN FRAMING TESTS ======== */
 
-/* The orchestrator escapes each turn so one logical message is one physical
-   stdin line (backslash -> "\\", newline -> "\n"); we decode it back here.
-   Regression guard for the restart-flood bug where a multi-line rehydration
-   preamble fanned out into one LLM turn (and one reply) per line. */
-static void test_unescape_newline_one_turn(void) {
-    TEST("unescape_turn: \\n decodes to real newlines");
-    char buf[256];
-    /* wire form: literal backslash-n between the lines (one physical line) */
-    strcpy(buf, "[From orchestrator] line1\\nline2\\nline3");
-    unescape_turn(buf);
-    if (strcmp(buf, "[From orchestrator] line1\nline2\nline3") == 0) PASS();
-    else FAIL(buf);
+/* A turn is framed by a delimiter, not by escaping its content: '\0' for a
+   driving program (pipe/FIFO), '\n' for a human at a tty. read_turn must hand
+   back the bytes between delimiters completely verbatim. Regression guard for
+   the restart-flood bug where a multi-line preamble fanned out into one LLM
+   turn (and one reply) per line. */
+static void test_turn_nul_keeps_newlines_one_turn(void) {
+    TEST("read_turn: NUL-framed multi-line stays one turn");
+    /* one turn carrying real newlines, ended by NUL, then a second turn */
+    FILE *f = fmemopen("line1\nline2\nline3\0second", 24, "r");
+    char *a = read_turn(f, '\0');
+    char *b = read_turn(f, '\0');
+    if (a && b && strcmp(a, "line1\nline2\nline3") == 0
+              && strcmp(b, "second") == 0) PASS();
+    else FAIL(a ? a : "(null)");
+    free(a); free(b); if (f) fclose(f);
 }
 
-static void test_unescape_literal_backslash(void) {
-    TEST("unescape_turn: \\\\ preserves a real backslash");
-    char buf[256];
-    /* wire form for user-typed "a\nb" (backslash, n) -> "a\\nb" on the wire */
-    strcpy(buf, "a\\\\nb");
-    unescape_turn(buf);
-    if (strcmp(buf, "a\\nb") == 0) PASS();   /* a, backslash, n, b — NOT a newline */
-    else FAIL(buf);
+static void test_turn_content_verbatim(void) {
+    TEST("read_turn: backslashes passed through verbatim");
+    /* "a\nb" as typed (backslash, n) must NOT become a newline */
+    FILE *f = fmemopen("a\\nb\0", 5, "r");
+    char *r = read_turn(f, '\0');
+    if (r && strcmp(r, "a\\nb") == 0) PASS();   /* a, backslash, n, b */
+    else FAIL(r ? r : "(null)");
+    free(r); if (f) fclose(f);
 }
 
-static void test_unescape_no_escapes(void) {
-    TEST("unescape_turn: plain text unchanged");
-    char buf[256];
-    strcpy(buf, "[From orchestrator] hello, what's live?");
-    unescape_turn(buf);
-    if (strcmp(buf, "[From orchestrator] hello, what's live?") == 0) PASS();
-    else FAIL(buf);
+static void test_turn_newline_framed_tty(void) {
+    TEST("read_turn: newline-framed turns (tty path)");
+    FILE *f = fmemopen("first\nsecond\n", 13, "r");
+    char *a = read_turn(f, '\n');
+    char *b = read_turn(f, '\n');
+    if (a && b && strcmp(a, "first") == 0 && strcmp(b, "second") == 0) PASS();
+    else FAIL(a ? a : "(null)");
+    free(a); free(b); if (f) fclose(f);
 }
 
-static void test_unescape_trailing_backslash(void) {
-    TEST("unescape_turn: lone trailing backslash kept");
-    char buf[256];
-    strcpy(buf, "ends with a backslash\\");
-    unescape_turn(buf);
-    if (strcmp(buf, "ends with a backslash\\") == 0) PASS();
-    else FAIL(buf);
+static void test_turn_eof_empty_is_null(void) {
+    TEST("read_turn: EOF with no bytes returns NULL");
+    FILE *f = fmemopen("", 0, "r");
+    char *r = read_turn(f, '\0');
+    if (r == NULL) PASS();
+    else FAIL(r);
+    free(r); if (f) fclose(f);
 }
 
 /* ======== JSON / TOOLS DEFINITION TESTS ======== */
@@ -345,10 +349,10 @@ int main(void) {
     test_shell_heredoc();
     test_shell_exit_code_ok();
     test_shell_exit_code_fail();
-    test_unescape_newline_one_turn();
-    test_unescape_literal_backslash();
-    test_unescape_no_escapes();
-    test_unescape_trailing_backslash();
+    test_turn_nul_keeps_newlines_one_turn();
+    test_turn_content_verbatim();
+    test_turn_newline_framed_tty();
+    test_turn_eof_empty_is_null();
     test_tools_definitions();
     test_parse_stop_response();
     test_parse_tool_calls_response();


### PR DESCRIPTION
## Context

PR #6 made the stdin protocol carry multi-line turns by **escaping** them on the wire (`\` → `\\`, `\n` → `\n`) and decoding with `unescape_turn` when stdin is not a tty. This follow-up keeps the goal — *one multi-line message = one turn* — but changes the mechanism, because the escaping approach has a real flaw.

## Problem with the escaping scheme

It conflates **framing** (where a turn ends) with **content encoding** (how bytes are represented). Once enabled for non-tty stdin, `unescape_turn` reinterprets **every** backslash in the input. So any driver that pipes content containing backslashes — C code with `\n`, JSON with escaped newlines, regex `\d`, Windows paths `C:\new`, LaTeX — gets it silently mangled. The "single-line turns are a no-op, fully backward compatible" claim only holds for content with no backslashes.

## Fix: frame by delimiter, leave content alone

A turn is delimited, not escaped:

- **tty (human):** a turn still ends with `\n` (one typed line = one turn). Unchanged.
- **non-tty (driver):** each turn ends with a **NUL byte**. A turn is text, so it can never contain a NUL → zero collision, content passed through **completely verbatim**. No escaping, no backslash reinterpretation.

`read_line()` becomes `read_turn(FILE *f, int delim)`; the delimiter is picked once via `isatty(STDIN_FILENO)`.

### Why this is better
- **Correct:** content (backslashes, newlines) survives byte-for-byte.
- **Simpler driver:** `printf '%s\0' "$turn"` per turn, vs. having to escape newlines (`sed`/`awk` in a shell driver).
- **Smaller surface:** removes `unescape_turn` entirely.
- **Standard unix idiom** (`find -print0`, `xargs -0`).

## Tests

Replaces the four `unescape_turn` tests with framing tests over `read_turn` (via `fmemopen`):
- NUL-framed multi-line message stays one turn (real newlines preserved);
- backslashes passed through verbatim (`a\nb` stays `a`,`\`,`n`,`b`, not a newline);
- newline-framed turns for the tty path;
- EOF with no bytes returns NULL.

`make test` → 23 passed, 0 failed; `make` compiles clean.

## Driver migration

Any orchestrator/`szc-wrapper` feeding piped stdin should send each turn as raw bytes followed by a NUL (`printf '%s\0'`) instead of escaping newlines into one line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated input handling system to use delimiter-based framing, with `\n` for interactive mode and `\0` for piped input, preserving embedded newlines verbatim.

* **Tests**
  * Replaced input decoding tests with new test suite covering input framing behavior across TTY and non-TTY scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->