### PR TITLE
Log the system prompt as a SYSTEM entry at session start

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -432,6 +432,10 @@ int main(int argc, char **argv) {
     char lp[600]; snprintf(lp, sizeof(lp), "%s/%s.txt", cfg.log_dir, sid);
     FILE *log = fopen(lp, "a");
     if (log) { time_t now = time(NULL); fprintf(log, "=== %s %s", sid, ctime(&now)); fflush(log); }
+    /* The system prompt (base prompt + concatenated skills) is the part of the
+       context the log could never reconstruct — two sessions with different
+       skill dirs would otherwise produce identical-looking logs. */
+    log_write(log, "SYSTEM", sysprompt);
 
     cJSON *msgs = cJSON_CreateArray();
     cJSON_AddItemToArray(msgs, make_msg("system", sysprompt));


### PR DESCRIPTION
## Why

The session log records USER/ASST/TOOL/RES lines but never the system prompt, so everything before the first user input — the base prompt and every skill `agent_build_system_prompt()` concatenates into it — is invisible. Two sessions with different skill dirs produce identical-looking logs, which is a blind spot when debugging why an agent behaved differently.

## What

One `log_write(log, "SYSTEM", sysprompt)` right after the session header, so the log opens with:

```
=== 0cc09cd00f41cacc Thu Jun 11 11:26:54 2026
[2026-06-11 11:26:54] SYSTEM: You are SubZeroClaw, a minimal agentic assistant.
...
--- SKILL: test-skill.md ---
...
[2026-06-11 11:26:54] USER: hello
```

Downstream, the genswarms log parser picks it up as a regular roled entry (`role: "system"`); companion PRs make the parser keep multi-line entries past blank lines and render it as a collapsed standout block in the dashboard timeline.

## Verification

Built and ran with a sandbox `$HOME`, dummy config, and one skill — log output above. (`make test` segfaults on macOS on clean main too — pre-existing, unrelated.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * System prompts are now logged to session files for improved session tracking and reconstruction across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->