### PR TITLE
Add optional SUBZEROCLAW_POLICY_IR env passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Environment variables override the config file:
 SUBZEROCLAW_API_KEY
 SUBZEROCLAW_MODEL
 SUBZEROCLAW_ENDPOINT
+SUBZEROCLAW_POLICY_IR   # optional: JSON policy_ir merged into each request (for policy-routing endpoints)
 ```
 
 ## Usage

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -202,6 +202,8 @@ static void response_free(Response *r) {
 static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
     cJSON *req = cJSON_CreateObject();
     cJSON_AddStringToObject(req, "model", cfg->model);
+    const char *pol = getenv("SUBZEROCLAW_POLICY_IR");  /* optional router policy JSON; unset = ignored */
+    if (pol && *pol) { cJSON *p = cJSON_Parse(pol); if (p) cJSON_AddItemToObject(req, "policy_ir", p); }
     cJSON_AddItemReferenceToObject(req, "messages", msgs);
     if (tools) cJSON_AddItemReferenceToObject(req, "tools", tools);
     char *json = cJSON_PrintUnformatted(req);


### PR DESCRIPTION
Lets an operator attach a router `policy_ir` to every chat request via one env var, for OpenAI-compatible endpoints that route by policy instead of a fixed model name.

```c
const char *pol = getenv("SUBZEROCLAW_POLICY_IR");  /* optional router policy JSON; unset = ignored */
if (pol && *pol) { cJSON *p = cJSON_Parse(pol); if (p) cJSON_AddItemToObject(req, "policy_ir", p); }
```

- **Opt-in, zero cost when unset** — a single `getenv` that returns `NULL`. Existing behavior unchanged.
- Malformed JSON is ignored (parse returns `NULL`), so a bad env can never break a request.
- `cJSON_AddItemToObject` takes ownership; freed with `req`. No leak.
- Set it like the other vars: `export SUBZEROCLAW_POLICY_IR='["policy", ...]'`.

+3 lines (2 code, 1 README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `SUBZEROCLAW_POLICY_IR` environment variable support. Users can set this environment variable to a JSON value that will be automatically merged into all policy-routing requests at runtime. This provides configuration flexibility without modifying code or files. The variable only affects policy-routing endpoints when configured. See README.md for details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->