### PR TITLE
feat: optional SUBZEROCLAW_REQUEST_EXTRA request-body override

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Environment variables override the config file:
 SUBZEROCLAW_API_KEY
 SUBZEROCLAW_MODEL
 SUBZEROCLAW_ENDPOINT
+SUBZEROCLAW_REQUEST_EXTRA   # optional: JSON object merged into every request body (e.g. {"temperature":0}); on a key collision the override wins
 ```
 
 ## Usage

--- a/config.example
+++ b/config.example
@@ -6,3 +6,4 @@ model = "minimax/minimax-m2.5"
 # endpoint = "https://openrouter.ai/api/v1/chat/completions"
 # skills_dir = "~/.subzeroclaw/skills"
 # max_turns = 50
+# request_extra = '{"temperature": 0.2}'  # optional JSON object merged into every request body

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -13,10 +13,12 @@
 #define MAX_PATH   512
 #define MAX_VALUE  1024
 #define MAX_OUTPUT (128 * 1024)
+#define MAX_EXTRA  8192   /* request_extra: an operator-supplied JSON body override */
 
 typedef struct {
     char api_key[MAX_VALUE], model[MAX_VALUE], endpoint[MAX_VALUE];
     char skills_dir[MAX_PATH], log_dir[MAX_PATH];
+    char request_extra[MAX_EXTRA];
     int  max_turns, max_messages;
 } Config;
 
@@ -26,6 +28,7 @@ static void config_parse_line(Config *cfg, const char *key, const char *val) {
     else if (!strcmp(key, "endpoint"))     snprintf(cfg->endpoint,   MAX_VALUE, "%s", val);
     else if (!strcmp(key, "skills_dir"))   snprintf(cfg->skills_dir, MAX_PATH,  "%s", val);
     else if (!strcmp(key, "log_dir"))      snprintf(cfg->log_dir,    MAX_PATH,  "%s", val);
+    else if (!strcmp(key, "request_extra")) snprintf(cfg->request_extra, MAX_EXTRA, "%s", val);
     else if (!strcmp(key, "max_turns"))    cfg->max_turns    = atoi(val);
     else if (!strcmp(key, "max_messages")) cfg->max_messages = atoi(val);
 }
@@ -64,6 +67,7 @@ int config_load(Config *cfg) {
     if ((v = getenv("SUBZEROCLAW_API_KEY")))  snprintf(cfg->api_key,  MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_MODEL")))    snprintf(cfg->model,    MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_ENDPOINT"))) snprintf(cfg->endpoint, MAX_VALUE, "%s", v);
+    if ((v = getenv("SUBZEROCLAW_REQUEST_EXTRA"))) snprintf(cfg->request_extra, MAX_EXTRA, "%s", v);
     if (!cfg->api_key[0]) { fprintf(stderr, "error: no api_key\n"); return -1; }
     return 0;
 }
@@ -202,11 +206,38 @@ static void response_free(Response *r) {
 static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
     cJSON *req = cJSON_CreateObject();
     cJSON_AddStringToObject(req, "model", cfg->model);
-    cJSON_AddItemReferenceToObject(req, "messages", msgs);
-    if (tools) cJSON_AddItemReferenceToObject(req, "tools", tools);
+
+    /* Optional operator-supplied request-body override (SUBZEROCLAW_REQUEST_EXTRA):
+       a JSON object whose top-level keys are merged in. Empty/unset → unchanged;
+       malformed → ignored; on a key collision the override wins. Applied before
+       messages/tools so it can replace `model` and add params (temperature, …)
+       without colliding with the reference items below. */
+    if (cfg->request_extra[0]) {
+        cJSON *extra = cJSON_Parse(cfg->request_extra);
+        if (extra && cJSON_IsObject(extra)) {
+            cJSON *it = NULL;
+            cJSON_ArrayForEach(it, extra) {
+                cJSON *dup = cJSON_Duplicate(it, 1);
+                if (!dup) continue;
+                cJSON_DeleteItemFromObject(req, it->string);  /* override wins */
+                cJSON_AddItemToObject(req, it->string, dup);
+            }
+        }
+        if (extra) cJSON_Delete(extra);
+    }
+
+    /* messages/tools are owned by the runtime and added by reference (not copied);
+       skip if the override already supplied them, so they are never duplicated. */
+    int msgs_ref = 0, tools_ref = 0;
+    if (!cJSON_GetObjectItem(req, "messages")) {
+        cJSON_AddItemReferenceToObject(req, "messages", msgs); msgs_ref = 1;
+    }
+    if (tools && !cJSON_GetObjectItem(req, "tools")) {
+        cJSON_AddItemReferenceToObject(req, "tools", tools); tools_ref = 1;
+    }
     char *json = cJSON_PrintUnformatted(req);
-    cJSON_DetachItemFromObject(req, "messages");
-    if (tools) cJSON_DetachItemFromObject(req, "tools");
+    if (msgs_ref)  cJSON_DetachItemFromObject(req, "messages");
+    if (tools_ref) cJSON_DetachItemFromObject(req, "tools");
     cJSON_Delete(req);
     return json;
 }

--- a/src/test.c
+++ b/src/test.c
@@ -303,6 +303,60 @@ static void test_build_request(void) {
     cJSON_Delete(msgs); cJSON_Delete(tools);
 }
 
+static void test_build_request_extra_merge(void) {
+    TEST("build_request: REQUEST_EXTRA merges, override wins");
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    snprintf(cfg.model, MAX_VALUE, "base-model");
+    snprintf(cfg.request_extra, MAX_EXTRA,
+        "{\"temperature\": 0.5, \"model\": \"override-model\"}");
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("user", "hi"));
+    char *json = build_request(&cfg, msgs, NULL);
+    assert(json);
+    cJSON *req = cJSON_Parse(json); assert(req);
+    cJSON *temp  = cJSON_GetObjectItem(req, "temperature");
+    cJSON *model = cJSON_GetObjectItem(req, "model");
+    cJSON *m     = cJSON_GetObjectItem(req, "messages");
+    int model_keys = 0; cJSON *c = NULL;
+    cJSON_ArrayForEach(c, req) if (c->string && !strcmp(c->string, "model")) model_keys++;
+    if (temp && cJSON_IsNumber(temp) && temp->valuedouble == 0.5 &&
+        model && !strcmp(model->valuestring, "override-model") &&  /* override wins */
+        model_keys == 1 &&                                          /* no duplicate */
+        m && cJSON_GetArraySize(m) == 1)
+        PASS();
+    else FAIL("merge/override mismatch");
+    cJSON_Delete(req); free(json); cJSON_Delete(msgs);
+}
+
+static void test_build_request_extra_empty(void) {
+    TEST("build_request: empty REQUEST_EXTRA leaves body unchanged");
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    snprintf(cfg.model, MAX_VALUE, "m");
+    cJSON *msgs = cJSON_CreateArray();
+    char *json = build_request(&cfg, msgs, NULL);
+    cJSON *req = cJSON_Parse(json); assert(req);
+    if (cJSON_GetArraySize(req) == 2 &&        /* exactly model + messages */
+        cJSON_GetObjectItem(req, "model") &&
+        cJSON_GetObjectItem(req, "messages"))
+        PASS();
+    else FAIL("body changed when unset");
+    cJSON_Delete(req); free(json); cJSON_Delete(msgs);
+}
+
+static void test_build_request_extra_garbage(void) {
+    TEST("build_request: malformed REQUEST_EXTRA ignored");
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    snprintf(cfg.model, MAX_VALUE, "m");
+    snprintf(cfg.request_extra, MAX_EXTRA, "{not valid json");
+    cJSON *msgs = cJSON_CreateArray();
+    char *json = build_request(&cfg, msgs, NULL);
+    cJSON *req = cJSON_Parse(json);            /* request must still be valid */
+    if (req && cJSON_GetObjectItem(req, "model") && cJSON_GetObjectItem(req, "messages"))
+        PASS();
+    else FAIL("garbage broke the request");
+    if (req) cJSON_Delete(req); free(json); cJSON_Delete(msgs);
+}
+
 /* ======== CONFIG TESTS ======== */
 
 static void test_config_no_key(void) {
@@ -359,6 +413,9 @@ int main(void) {
     test_parse_error_response();
     test_parse_garbage();
     test_build_request();
+    test_build_request_extra_merge();
+    test_build_request_extra_empty();
+    test_build_request_extra_garbage();
     test_full_tool_dispatch();
     test_system_prompt();
     test_skills_loading();


### PR DESCRIPTION
## Problem (independent of solution)

`build_request` fixes the request body to `{model, messages, tools}`. An operator cannot set **any** parameter the OpenAI-compatible endpoint accepts — `temperature`, `max_tokens`, `reasoning`, `provider`, `transforms`, or a custom host's `policy_ir`. On edge hardware, not being able to cap `max_tokens` or pin `temperature` is a real runtime limitation today.

This generalizes #11 (which added a `policy_ir`-specific env). The concrete "can't send policy_ir" is one instance of the general "can't send any body parameter"; the general form is the Kolmogorov-minimal answer (one channel instead of a knob per field) and keeps the runtime from naming any provider concept.

## Form delta

- **Definition:** one optional request-body override — a JSON **object**, empty/unset by default, whose top-level keys are merged into the body. The runtime knows no key by name.
- **Invariants:**
  - unset/empty → body **byte-identical** to before (zero cost).
  - malformed JSON → ignored (request never breaks).
  - key collision → **the override wins** (e.g. it may replace `model`).
  - `messages`/`tools` are runtime-owned, added by reference; the override can never duplicate or leak them.
- **Essence (tests):** `test_build_request_extra_{merge,empty,garbage}` — 3 new cases, suite **23 → 26, 0 failures**.
- **Locus:** resolved in `config_load` (config file **and** `SUBZEROCLAW_REQUEST_EXTRA` env, symmetric with the other vars); merged in `build_request`. Stored in a fixed `MAX_EXTRA` (8 KB) buffer — `Config` stays POD, no new allocation.

## Verification

```
make test   # 26 passed, 0 failed
make        # clean build, -Wall -Wextra
```

Supersedes #11 — closes the same need without coupling the runtime to any router vocabulary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration to merge custom JSON fields into every API request body, with override precedence for key collisions.

* **Documentation**
  * Updated README with environment variable configuration details.

* **Tests**
  * Added unit tests validating request merging behavior with various configurations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->