### PR TITLE
config_load: scrub provider config from the env after reading it

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -69,6 +69,27 @@ int config_load(Config *cfg) {
     if ((v = getenv("SUBZEROCLAW_ENDPOINT"))) snprintf(cfg->endpoint, MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_REQUEST_EXTRA"))) snprintf(cfg->request_extra, MAX_EXTRA, "%s", v);
     if (!cfg->api_key[0]) { fprintf(stderr, "error: no api_key\n"); return -1; }
+
+    /* Scrub the provider config from our own environment now that it lives in cfg.
+       The one tool we expose, "shell", runs commands via popen() (/bin/sh -c),
+       which inherits this process's environment — so without this an LLM-driven
+       command could read the key/endpoint with `echo $SUBZEROCLAW_API_KEY`, `env`,
+       or by catting /proc/<pid>/environ. unsetenv() alone is NOT enough: getenv()
+       returns a pointer into the original environment region that
+       /proc/<pid>/environ exposes, and unsetenv() leaves those bytes intact — so
+       wipe the value in place first, then remove the name. The values remain in
+       cfg, so requests are unaffected. */
+    {
+        static const char *const secret_vars[] = {
+            "SUBZEROCLAW_API_KEY", "SUBZEROCLAW_MODEL",
+            "SUBZEROCLAW_ENDPOINT", "SUBZEROCLAW_REQUEST_EXTRA"
+        };
+        for (size_t i = 0; i < sizeof(secret_vars) / sizeof(secret_vars[0]); i++) {
+            char *p = getenv(secret_vars[i]);
+            if (p) memset(p, 0, strlen(p));
+            unsetenv(secret_vars[i]);
+        }
+    }
     return 0;
 }
 

--- a/src/test.c
+++ b/src/test.c
@@ -389,6 +389,37 @@ static void test_config_defaults(void) {
     unsetenv("SUBZEROCLAW_API_KEY");
 }
 
+static void test_config_scrubs_env(void) {
+    TEST("config: scrubs provider env after load");
+    char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
+    setenv("HOME", "/tmp/szc_no_config", 1); /* skip any real config file */
+    setenv("SUBZEROCLAW_API_KEY", "sk-test-scrub", 1);
+    setenv("SUBZEROCLAW_MODEL", "test/model", 1);
+    setenv("SUBZEROCLAW_ENDPOINT", "https://test.example/v1/chat", 1);
+    setenv("SUBZEROCLAW_REQUEST_EXTRA", "{\"temperature\":0}", 1);
+    Config cfg;
+    int rc = config_load(&cfg);
+    if (old_home) { setenv("HOME", old_home, 1); free(old_home); }
+    else unsetenv("HOME");
+
+    /* values survive in cfg, so requests are unaffected... */
+    int cfg_ok = rc == 0 &&
+        strcmp(cfg.api_key, "sk-test-scrub") == 0 &&
+        strcmp(cfg.model, "test/model") == 0 &&
+        strcmp(cfg.endpoint, "https://test.example/v1/chat") == 0 &&
+        strcmp(cfg.request_extra, "{\"temperature\":0}") == 0;
+    /* ...but are gone from the environment the shell tool inherits */
+    int env_scrubbed =
+        getenv("SUBZEROCLAW_API_KEY") == NULL &&
+        getenv("SUBZEROCLAW_MODEL") == NULL &&
+        getenv("SUBZEROCLAW_ENDPOINT") == NULL &&
+        getenv("SUBZEROCLAW_REQUEST_EXTRA") == NULL;
+
+    if (cfg_ok && env_scrubbed) PASS();
+    else if (!cfg_ok) FAIL("cfg lost a provider value");
+    else FAIL("env not scrubbed after load");
+}
+
 /* ======== MAIN ======== */
 
 int main(void) {
@@ -421,6 +452,7 @@ int main(void) {
     test_skills_loading();
     test_config_no_key();
     test_config_defaults();
+    test_config_scrubs_env();
 
     printf("\n  ═══════════════════════════════════════════\n");
     printf("  %d passed, %d failed\n\n", tests_passed, tests_failed);


### PR DESCRIPTION
## Problem

`subzeroclaw` exposes a single tool, `shell`, and runs the model's command via `popen()` (`/bin/sh -c`), which inherits the process environment. The provider config read from `SUBZEROCLAW_API_KEY` / `_MODEL` / `_ENDPOINT` / `_REQUEST_EXTRA` therefore stays readable by any LLM-driven command — `echo $SUBZEROCLAW_API_KEY`, `env`, or `cat /proc/<pid>/environ` — and can be exfiltrated by a prompt-injected or misbehaving model.

## Fix

After `config_load` copies the values into `cfg`, scrub them from the environment: `memset` the value bytes in place, then `unsetenv` the name. The values live on in `cfg`, so API calls are unaffected.

`memset` before `unsetenv` is required: `getenv()` returns a pointer into the original environment region that `/proc/<pid>/environ` reads, and `unsetenv()` leaves those bytes intact. Verified on Linux:

- plain `unsetenv` → `/proc/self/environ` **still contains** the value (only `getenv` clears).
- `memset(value, 0, len)` + `unsetenv` → value gone from `getenv`, `env`, and `/proc/<pid>/environ`.

~16 lines in `config_load`, no behavior change to requests. Static build verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sensitive provider credentials and configuration parameters are now cleared from the process environment after being loaded, so child processes can no longer access them via environment inspection.
  * Added an automated test to verify the credentials are removed from the environment while the loaded configuration remains available to the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->