### PR TITLE
Fix heap overflow in tool_execute output read loop

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -173,8 +173,16 @@ char *tool_execute(const char *name, const char *args_json) {
     /* Reserve 16 bytes at the head for the "[exit:N] " prefix */
     char *out = malloc(MAX_OUTPUT + 16);
     size_t total = 16, n;
-    while ((n = fread(out + total, 1, MAX_OUTPUT - 1, fp)) > 0) {
-        total += n; if (total >= MAX_OUTPUT + 15) break;
+    /* Bound each read by the space left in `out` (cap = MAX_OUTPUT+16, with
+       out[total] reserved for the trailing NUL). The previous loop kept the
+       per-read count at MAX_OUTPUT-1 even as `total` grew, so the SECOND fread
+       on any tool output under ~128KB ran past the buffer. On a fortified (-O2,
+       Ubuntu-default _FORTIFY_SOURCE) glibc build that is a fatal __fread_chk
+       abort (SIGABRT) — it silently killed the agent the moment it read back a
+       small tool result (e.g. a `swarm-msg ask` envelope), wedging the turn. */
+    while (total < MAX_OUTPUT + 15 &&
+           (n = fread(out + total, 1, (MAX_OUTPUT + 15) - total, fp)) > 0) {
+        total += n;
     }
     out[total] = '\0';
     int status = pclose(fp);


### PR DESCRIPTION
## Problem

`tool_execute()` reads a tool's stdout into `out = malloc(MAX_OUTPUT + 16)` with:

```c
while ((n = fread(out + total, 1, MAX_OUTPUT - 1, fp)) > 0) {
    total += n; if (total >= MAX_OUTPUT + 15) break;
}
```

The per-read count stays `MAX_OUTPUT - 1` regardless of `total`. After the first read leaves `total > 17`, the next `fread` can write up to `MAX_OUTPUT - 1` bytes starting at `out + total`, running past the end of the buffer. This triggers on any tool whose output is smaller than ~128KB — i.e. almost all of them; the loop only avoids a second read when a single read already fills the buffer.

On a fortified glibc build (Ubuntu gcc defaults `-D_FORTIFY_SOURCE` at `-O2`), `__fread_chk` detects the over-read and aborts with `*** buffer overflow detected ***` (SIGABRT). gdb backtrace of the core:

```
__fread_chk → tool_execute → process_tool_calls → agent_run
```

On non-fortified builds (e.g. clang/macOS) the same overflow is a latent out-of-bounds write.

## Fix

Bound each read by the space remaining in the buffer.

## Test

Reproduced deterministically with a two-call tool turn (small tool result read back through `tool_execute`): aborted with exit 134 (SIGABRT) before the change, exits 0 after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash/abort issue when handling large tool outputs. Output buffering now properly respects the remaining space in the buffer, preventing potential overreads and improving reliability on systems with stricter safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->