### PR TITLE
Compact context by estimated token budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,15 @@ Every session gets a random hex ID. All input, output, tool calls, and results a
 
 ## Context compaction
 
-When the message history exceeds `max_messages` (default 40), the agent:
+When the estimated outbound request exceeds `max_context_tokens` (default 24000), the agent:
 
 1. Sends old messages to the LLM for summarization
 2. Replaces them with the summary
-3. Keeps the last N raw messages intact
+3. Keeps recent raw messages intact, without splitting a message or orphaning tool output
 
-No vector DB. No embeddings. One API call to compress context.
+The token count is a local estimate from the serialized request, so compaction
+happens before the model call. No vector DB. No embeddings. One API call to
+compress context.
 
 ## Config reference
 
@@ -190,7 +192,7 @@ No vector DB. No embeddings. One API call to compress context.
 | `skills_dir` | `~/.subzeroclaw/skills` | Path to skill markdown files |
 | `log_dir` | `~/.subzeroclaw/logs` | Session log directory |
 | `max_turns` | 200 | Max tool-call loops per input |
-| `max_messages` | 40 | Trigger context compaction |
+| `max_context_tokens` | 24000 | Estimated request-token budget before compaction |
 
 ## Troubleshooting
 

--- a/config.example
+++ b/config.example
@@ -6,4 +6,5 @@ model = "minimax/minimax-m2.5"
 # endpoint = "https://openrouter.ai/api/v1/chat/completions"
 # skills_dir = "~/.subzeroclaw/skills"
 # max_turns = 50
+# max_context_tokens = 24000
 # request_extra = '{"temperature": 0.2}'  # optional JSON object merged into every request body

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -366,6 +366,8 @@ static int compact_messages(const Config *cfg, cJSON *msgs, cJSON *tools, FILE *
     if (cfg->max_context_tokens <= 0) return 0;
     int tokens = estimate_request_tokens(cfg, msgs, tools);
     if (tokens <= cfg->max_context_tokens) return 0;
+    int start = retention_start_index(cfg, msgs);
+    if (start <= 1) return 0;
     fprintf(stderr, "[compact] ~%d tokens, summarizing\n", tokens);
     log_write(log, "SYS", "compacting context");
 
@@ -373,9 +375,9 @@ static int compact_messages(const Config *cfg, cJSON *msgs, cJSON *tools, FILE *
     size_t cap = 512000, len = 0;
     char *convo = malloc(cap);
     convo[0] = '\0';
-    cJSON *m = NULL;
-    cJSON_ArrayForEach(m, msgs) {
+    for (int i = 1; i < start; i++) {
         if (len + 256 >= cap) break;
+        cJSON *m = cJSON_GetArrayItem(msgs, i);
         cJSON *role = cJSON_GetObjectItem(m, "role");
         cJSON *ct = cJSON_GetObjectItem(m, "content");
         if (!role || !cJSON_IsString(role) || !ct || !cJSON_IsString(ct)) continue;
@@ -405,8 +407,6 @@ static int compact_messages(const Config *cfg, cJSON *msgs, cJSON *tools, FILE *
     if (parse_response(rb, &resp) != 0 || !resp.text) { free(rb); response_free(&resp); return -1; }
     char *summary = strdup(resp.text); free(rb); response_free(&resp);
     log_write(log, "COMPACT", summary);
-
-    int start = retention_start_index(cfg, msgs);
 
     for (int i = start - 1; i >= 1; i--)
         cJSON_DeleteItemFromArray(msgs, i);
@@ -454,7 +454,7 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
     log_write(log, "USER", input);
 
     for (int turn = 1; turn <= cfg->max_turns; turn++) {
-        compact_messages(cfg, msgs, tools, log);
+        if (compact_messages(cfg, msgs, tools, log) < 0) return -1;
         fprintf(stderr, "[%d] %s...\n", turn, cfg->model);
         char *rb = llm_chat(cfg, msgs, tools);
         if (!rb) return -1;

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -19,7 +19,7 @@ typedef struct {
     char api_key[MAX_VALUE], model[MAX_VALUE], endpoint[MAX_VALUE];
     char skills_dir[MAX_PATH], log_dir[MAX_PATH];
     char request_extra[MAX_EXTRA];
-    int  max_turns, max_messages;
+    int  max_turns, max_context_tokens;
 } Config;
 
 static void config_parse_line(Config *cfg, const char *key, const char *val) {
@@ -30,7 +30,7 @@ static void config_parse_line(Config *cfg, const char *key, const char *val) {
     else if (!strcmp(key, "log_dir"))      snprintf(cfg->log_dir,    MAX_PATH,  "%s", val);
     else if (!strcmp(key, "request_extra")) snprintf(cfg->request_extra, MAX_EXTRA, "%s", val);
     else if (!strcmp(key, "max_turns"))    cfg->max_turns    = atoi(val);
-    else if (!strcmp(key, "max_messages")) cfg->max_messages = atoi(val);
+    else if (!strcmp(key, "max_context_tokens")) cfg->max_context_tokens = atoi(val);
 }
 
 int config_load(Config *cfg) {
@@ -41,7 +41,7 @@ int config_load(Config *cfg) {
     snprintf(cfg->model,      MAX_VALUE, "minimax/minimax-m2.5");
     snprintf(cfg->skills_dir, MAX_PATH,  "%s/.subzeroclaw/skills", home);
     snprintf(cfg->log_dir,    MAX_PATH,  "%s/.subzeroclaw/logs", home);
-    cfg->max_turns = 200; cfg->max_messages = 40;
+    cfg->max_turns = 200; cfg->max_context_tokens = 24000;
 
     char path[MAX_PATH];
     snprintf(path, MAX_PATH, "%s/.subzeroclaw/config", home);
@@ -271,6 +271,27 @@ static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
     return json;
 }
 
+static int estimate_tokens(const char *s) {
+    size_t len = s ? strlen(s) : 0;
+    return len ? (int)((len + 3) / 4) : 0;
+}
+
+static int estimate_json_tokens(cJSON *item) {
+    char *json = cJSON_PrintUnformatted(item);
+    if (!json) return 0;
+    int tokens = estimate_tokens(json);
+    free(json);
+    return tokens;
+}
+
+static int estimate_request_tokens(const Config *cfg, cJSON *msgs, cJSON *tools) {
+    char *json = build_request(cfg, msgs, tools);
+    if (!json) return 0;
+    int tokens = estimate_tokens(json);
+    free(json);
+    return tokens;
+}
+
 #if defined(__GNUC__) || defined(__clang__)
 #define SZC_WEAK __attribute__((weak))
 #else
@@ -317,10 +338,35 @@ static cJSON *make_msg(const char *role, const char *content) {
     return m;
 }
 
-static int compact_messages(const Config *cfg, cJSON *msgs, FILE *log) {
+static int msg_is_role(cJSON *msg, const char *want) {
+    cJSON *role = cJSON_GetObjectItem(msg, "role");
+    return role && cJSON_IsString(role) && !strcmp(role->valuestring, want);
+}
+
+static int retention_start_index(const Config *cfg, cJSON *msgs) {
     int total = cJSON_GetArraySize(msgs);
-    if (total <= cfg->max_messages) return 0;
-    fprintf(stderr, "[compact] %d msgs, summarizing\n", total);
+    int budget = cfg->max_context_tokens > 1 ? cfg->max_context_tokens / 2 : 1;
+    int used = 0, start = total;
+
+    for (int i = total - 1; i >= 1; i--) {
+        int tokens = estimate_json_tokens(cJSON_GetArrayItem(msgs, i));
+        if (start < total && used + tokens > budget) break;
+        used += tokens;
+        start = i;
+        if (used > budget) break; /* keep the newest message whole */
+    }
+
+    if (start < 1) start = 1;
+    while (start > 1 && msg_is_role(cJSON_GetArrayItem(msgs, start), "tool"))
+        start--;
+    return start;
+}
+
+static int compact_messages(const Config *cfg, cJSON *msgs, cJSON *tools, FILE *log) {
+    if (cfg->max_context_tokens <= 0) return 0;
+    int tokens = estimate_request_tokens(cfg, msgs, tools);
+    if (tokens <= cfg->max_context_tokens) return 0;
+    fprintf(stderr, "[compact] ~%d tokens, summarizing\n", tokens);
     log_write(log, "SYS", "compacting context");
 
     /* build text digest — keep user/assistant in full, trim only tool outputs */
@@ -360,15 +406,7 @@ static int compact_messages(const Config *cfg, cJSON *msgs, FILE *log) {
     char *summary = strdup(resp.text); free(rb); response_free(&resp);
     log_write(log, "COMPACT", summary);
 
-    /* keep last ~10 msgs, but skip orphaned tool msgs at the boundary
-       (their tool_call_ids reference deleted assistant msgs → API rejects) */
-    int start = total - 10;
-    if (start < 1) start = 1;
-    while (start < total - 1) {
-        cJSON *r = cJSON_GetObjectItem(cJSON_GetArrayItem(msgs, start), "role");
-        if (!r || strcmp(r->valuestring, "tool") != 0) break;
-        start++;
-    }
+    int start = retention_start_index(cfg, msgs);
 
     for (int i = start - 1; i >= 1; i--)
         cJSON_DeleteItemFromArray(msgs, i);
@@ -416,7 +454,7 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
     log_write(log, "USER", input);
 
     for (int turn = 1; turn <= cfg->max_turns; turn++) {
-        compact_messages(cfg, msgs, log);
+        compact_messages(cfg, msgs, tools, log);
         fprintf(stderr, "[%d] %s...\n", turn, cfg->model);
         char *rb = llm_chat(cfg, msgs, tools);
         if (!rb) return -1;

--- a/src/test.c
+++ b/src/test.c
@@ -430,6 +430,21 @@ static void test_retention_does_not_start_with_tool(void) {
     cJSON_Delete(msgs);
 }
 
+static void test_compact_skips_without_removable_prefix(void) {
+    TEST("compact: skips without removable prefix");
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    snprintf(cfg.model, MAX_VALUE, "m");
+    cfg.max_context_tokens = 40;
+    char big[512]; memset(big, 'x', sizeof(big) - 1); big[sizeof(big) - 1] = '\0';
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("system", "sys"));
+    cJSON_AddItemToArray(msgs, make_msg("user", big));
+    int rc = compact_messages(&cfg, msgs, NULL, NULL);
+    if (rc == 0 && cJSON_GetArraySize(msgs) == 2) PASS();
+    else FAIL("summary inserted without deleting old context");
+    cJSON_Delete(msgs);
+}
+
 /* ======== CONFIG TESTS ======== */
 
 static void test_config_no_key(void) {
@@ -547,6 +562,7 @@ int main(void) {
     test_retention_keeps_small_recent_messages();
     test_retention_keeps_large_latest_whole();
     test_retention_does_not_start_with_tool();
+    test_compact_skips_without_removable_prefix();
     test_full_tool_dispatch();
     test_system_prompt();
     test_skills_loading();

--- a/src/test.c
+++ b/src/test.c
@@ -357,6 +357,79 @@ static void test_build_request_extra_garbage(void) {
     if (req) cJSON_Delete(req); free(json); cJSON_Delete(msgs);
 }
 
+/* ======== CONTEXT TOKEN ESTIMATE TESTS ======== */
+
+static void test_estimate_tokens_rounds_up(void) {
+    TEST("estimate_tokens: rounds up");
+    if (estimate_tokens("") == 0 &&
+        estimate_tokens("a") == 1 &&
+        estimate_tokens("abcd") == 1 &&
+        estimate_tokens("abcde") == 2)
+        PASS();
+    else FAIL("bad estimate");
+}
+
+static void test_estimate_request_tokens_includes_tools(void) {
+    TEST("estimate_request_tokens: includes tools");
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    snprintf(cfg.model, MAX_VALUE, "m");
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("user", "hi"));
+    cJSON *tools = cJSON_Parse(TOOLS_JSON);
+    int without = estimate_request_tokens(&cfg, msgs, NULL);
+    int with = estimate_request_tokens(&cfg, msgs, tools);
+    if (with > without) PASS();
+    else FAIL("tools missing from estimate");
+    cJSON_Delete(msgs); cJSON_Delete(tools);
+}
+
+static void test_retention_keeps_small_recent_messages(void) {
+    TEST("retention: keeps small recent messages");
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    cfg.max_context_tokens = 1000;
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("system", "sys"));
+    for (int i = 0; i < 5; i++)
+        cJSON_AddItemToArray(msgs, make_msg("user", "short"));
+    if (retention_start_index(&cfg, msgs) == 1) PASS();
+    else FAIL("small messages dropped");
+    cJSON_Delete(msgs);
+}
+
+static void test_retention_keeps_large_latest_whole(void) {
+    TEST("retention: keeps large latest whole");
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    cfg.max_context_tokens = 40;
+    char big[256]; memset(big, 'x', sizeof(big) - 1); big[sizeof(big) - 1] = '\0';
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("system", "sys"));
+    cJSON_AddItemToArray(msgs, make_msg("user", "old"));
+    cJSON_AddItemToArray(msgs, make_msg("assistant", big));
+    if (retention_start_index(&cfg, msgs) == 2) PASS();
+    else FAIL("latest message split or dropped");
+    cJSON_Delete(msgs);
+}
+
+static void test_retention_does_not_start_with_tool(void) {
+    TEST("retention: does not start with tool");
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    cfg.max_context_tokens = 24;
+    char old[160]; memset(old, 'o', sizeof(old) - 1); old[sizeof(old) - 1] = '\0';
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("system", "sys"));
+    cJSON_AddItemToArray(msgs, make_msg("user", old));
+    cJSON_AddItemToArray(msgs, make_msg("assistant", "tool call"));
+    cJSON *tool = cJSON_CreateObject();
+    cJSON_AddStringToObject(tool, "role", "tool");
+    cJSON_AddStringToObject(tool, "tool_call_id", "call_test");
+    cJSON_AddStringToObject(tool, "content", "result");
+    cJSON_AddItemToArray(msgs, tool);
+    int start = retention_start_index(&cfg, msgs);
+    if (start == 2 && !msg_is_role(cJSON_GetArrayItem(msgs, start), "tool")) PASS();
+    else FAIL("retained suffix starts with tool");
+    cJSON_Delete(msgs);
+}
+
 /* ======== CONFIG TESTS ======== */
 
 static void test_config_no_key(void) {
@@ -377,16 +450,38 @@ static void test_config_no_key(void) {
 
 static void test_config_defaults(void) {
     TEST("config: loads with env var");
+    char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
+    setenv("HOME", "/tmp/szc_no_config", 1);
     setenv("SUBZEROCLAW_API_KEY", "sk-test-fake-key", 1);
     Config cfg;
     int rc = config_load(&cfg);
+    if (old_home) { setenv("HOME", old_home, 1); free(old_home); }
+    else unsetenv("HOME");
     if (rc == 0 &&
         strcmp(cfg.api_key, "sk-test-fake-key") == 0 &&
-        strstr(cfg.endpoint, "openrouter.ai"))
+        strstr(cfg.endpoint, "openrouter.ai") &&
+        cfg.max_context_tokens == 24000)
         PASS();
     else
         FAIL("config mismatch");
     unsetenv("SUBZEROCLAW_API_KEY");
+}
+
+static void test_config_max_context_tokens_file(void) {
+    TEST("config: max_context_tokens from file");
+    system("rm -rf /tmp/szc_ctx_config && mkdir -p /tmp/szc_ctx_config/.subzeroclaw");
+    FILE *f = fopen("/tmp/szc_ctx_config/.subzeroclaw/config", "w");
+    fprintf(f, "api_key = \"sk-test-file\"\nmax_context_tokens = 12345\n");
+    fclose(f);
+    char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
+    setenv("HOME", "/tmp/szc_ctx_config", 1);
+    Config cfg;
+    int rc = config_load(&cfg);
+    if (old_home) { setenv("HOME", old_home, 1); free(old_home); }
+    else unsetenv("HOME");
+    system("rm -rf /tmp/szc_ctx_config");
+    if (rc == 0 && cfg.max_context_tokens == 12345) PASS();
+    else FAIL("max_context_tokens not loaded");
 }
 
 static void test_config_scrubs_env(void) {
@@ -447,11 +542,17 @@ int main(void) {
     test_build_request_extra_merge();
     test_build_request_extra_empty();
     test_build_request_extra_garbage();
+    test_estimate_tokens_rounds_up();
+    test_estimate_request_tokens_includes_tools();
+    test_retention_keeps_small_recent_messages();
+    test_retention_keeps_large_latest_whole();
+    test_retention_does_not_start_with_tool();
     test_full_tool_dispatch();
     test_system_prompt();
     test_skills_loading();
     test_config_no_key();
     test_config_defaults();
+    test_config_max_context_tokens_file();
     test_config_scrubs_env();
 
     printf("\n  ═══════════════════════════════════════════\n");


### PR DESCRIPTION
## Problem

`max_messages` compacts by transcript length, not request size. A few huge tool outputs can overflow context before the message count is high, while many short turns can compact too early.

## Fix

Replace the active compaction trigger with `max_context_tokens`, estimated from the serialized outbound request. Compaction still happens before the model call and still keeps whole recent messages.

The retained suffix is now chosen by estimated token budget instead of a fixed last-10 count. It keeps whole messages, and if the boundary would start inside tool output it snaps back to include the preceding assistant/tool-call group rather than sending orphaned `tool` messages.

If the current over-budget request has no removable prefix, compaction is skipped instead of inserting a summary that makes context larger. The summary prompt is built only from the prefix that will actually be deleted.

## Invariants

- no tokenizer dependency
- no provider-specific context lookup
- whole messages only; never cut through content
- retained suffix never starts with an orphan `tool` message
- tests do not call a real LLM

## Testing

```bash
docker run --rm -v "$PWD":/src -w /src debian:bookworm sh -lc 'apt-get update >/dev/null && apt-get install -y build-essential make >/dev/null && make clean >/dev/null && make HAVE_SYSTEM_CJSON=no && make HAVE_SYSTEM_CJSON=no test'
# 34 passed, 0 failed

make HAVE_SYSTEM_CJSON=no
```
