### PR TITLE
feat: SubZeroClaw → unhardcoded client — route + async-compact via two JSONs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You write a skill as a markdown file. You point SubZeroClaw at it. It calls an L
 
 ```
 ~/.subzeroclaw/skills/monitor.md    ← what the agent knows
-~/.subzeroclaw/config               ← API key + model
+~/.subzeroclaw/config               ← API key + request_extra (model / routing policy)
 ~/.subzeroclaw/logs/<session>.txt   ← full I/O trace
 ```
 
@@ -36,13 +36,38 @@ make                          # builds the 54KB binary in ~0.5s
 mkdir -p ~/.subzeroclaw/skills
 cat > ~/.subzeroclaw/config << 'EOF'
 api_key = "sk-or-your-openrouter-key"
-model = "minimax/minimax-m2.5"
+# The model is no longer a dedicated key — it rides in request_extra (the generic
+# body-override channel). Direct provider: set the model. Against an unhardcoded
+# router: send a policy instead — see "Routing & compaction via unhardcoded".
+request_extra = "{\"model\": \"minimax/minimax-m2.5\"}"
 EOF
 
 ./subzeroclaw "check disk usage and clean tmp if over 80%"
 ```
 
 Clone, build, drop in an [OpenRouter](https://openrouter.ai) key, run. No daemon to register, no service to start. You need `gcc` to build and `curl` at runtime — everything else is in the box.
+
+## Routing & compaction via unhardcoded
+
+Two things a long agent loop needs — **routing with prompt-cache affinity** and
+**context compaction** — were never part of "skill + LLM + shell + loop". They
+belong to the substrate, not the agent. So rather than grow that logic in C,
+SubZeroClaw points its `endpoint` at [**unhardcoded**](https://github.com/genlayerlabs/unhardcoded)
+(MIT, open source) and expresses the behaviour as JSON instead of code:
+
+- **The loop** — `request_extra` carries a routing policy and the model. The
+  router picks the (provider, model) per call and keeps the conversation pinned
+  to the peer that already holds its prompt-cache prefix (SubZeroClaw sends a
+  per-run `session` id for that affinity), e.g.
+  `{"model":"policy:auto","policy_ir":[ "policy", … cache_hot affinity … ]}`.
+- **Compaction** — the router seals the aged context append-only and signals when
+  (an `x_router.compact` flag on the response), so the agent never re-summarizes
+  in C. *(The agent-side wiring lands in the companion change.)*
+
+This is SubZeroClaw being *more* itself: the loop, the shell, the skill — plus a
+single MIT dependency for the substrate concerns. Point `endpoint` at a plain
+provider instead (with a `model` in `request_extra`) and it runs standalone — no
+routing, no cache, no compaction — exactly as before.
 
 ## Why not just use ZeroClaw / OpenClaw?
 
@@ -102,7 +127,10 @@ mkdir -p ~/.subzeroclaw/skills
 
 cat > ~/.subzeroclaw/config << EOF
 api_key = "sk-or-your-openrouter-key"
-model = "minimax/minimax-m2.5"
+# The model is no longer a dedicated key — it rides in request_extra (the generic
+# body-override channel). Direct provider: set the model. Against an unhardcoded
+# router: send a policy instead — see "Routing & compaction via unhardcoded".
+request_extra = "{\"model\": \"minimax/minimax-m2.5\"}"
 EOF
 ```
 
@@ -118,9 +146,11 @@ Environment variables override the config file:
 
 ```
 SUBZEROCLAW_API_KEY
-SUBZEROCLAW_MODEL
 SUBZEROCLAW_ENDPOINT
-SUBZEROCLAW_REQUEST_EXTRA   # optional: JSON object merged into every request body (e.g. {"temperature":0}); on a key collision the override wins
+SUBZEROCLAW_REQUEST_EXTRA   # JSON merged into every request body. Carries the model
+                           #   ({"model":"..."}); against an unhardcoded router it carries
+                           #   the routing policy too ({"model":"policy:auto","policy_ir":[...]}).
+                           #   On a key collision the override wins.
 ```
 
 ## Usage
@@ -184,9 +214,9 @@ No vector DB. No embeddings. One API call to compress context.
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `api_key` | (required) | OpenRouter API key |
-| `model` | `minimax/minimax-m2.5` | Any OpenAI-compatible model |
-| `endpoint` | `https://openrouter.ai/api/v1/chat/completions` | API endpoint |
+| `api_key` | (required) | OpenRouter (or unhardcoded) API key |
+| `request_extra` | (none) | JSON merged into every request body — carries the `model`, and against an unhardcoded router the routing `policy_ir` |
+| `endpoint` | `https://openrouter.ai/api/v1/chat/completions` | API endpoint (point it at an unhardcoded router for routing/cache/compaction) |
 | `skills_dir` | `~/.subzeroclaw/skills` | Path to skill markdown files |
 | `log_dir` | `~/.subzeroclaw/logs` | Session log directory |
 | `max_turns` | 200 | Max tool-call loops per input |
@@ -198,7 +228,7 @@ No vector DB. No embeddings. One API call to compress context.
 |---------|-----|
 | `curl: command not found` or no response from the model | The runtime shells out to `curl` for API calls. Install it: `sudo apt install curl`. |
 | `401 Unauthorized` from the endpoint | Missing or invalid key. Check `api_key` in `~/.subzeroclaw/config` or the `SUBZEROCLAW_API_KEY` env var. |
-| Model never calls tools / loops without progress | Use a `model` that supports tool calling — not every OpenRouter model does. |
+| Model never calls tools / loops without progress | Use a model that supports tool calling (set it in `request_extra`) — not every model does. |
 | `make` fails on a fresh Pi | Install a compiler: `sudo apt install build-essential`. The vendored cJSON is used automatically when `libcjson-dev` is absent. |
 
 ## Source

--- a/README.md
+++ b/README.md
@@ -69,10 +69,14 @@ SubZeroClaw points its `endpoint` at [**unhardcoded**](https://github.com/genlay
   keep verbatim ride in `SUBZEROCLAW_COMPACT_EXTRA` (the second JSON), e.g.
   `{"keep_recent":8,"policy_ir":[ "policy", … cheap summariser … ]}`.
 
-This is SubZeroClaw being *more* itself: the loop, the shell, the skill — plus a
-single MIT dependency for the substrate concerns. Point `endpoint` at a plain
-provider instead (with a `model` in `request_extra`) and it runs standalone — no
-routing, no cache, no compaction — exactly as before.
+This is SubZeroClaw being *more* itself: the loop, the shell, the skill — on a
+substrate that carries everything that was never "skill + LLM + shell + loop".
+unhardcoded (MIT) is part of that substrate, on the same footing as the Linux
+shell it `popen`s: just as there is no agent without a terminal, there is no
+routing, cache, or compaction without the router. The runtime is designed to run
+on unhardcoded — point `endpoint` at a bare provider and the HTTP call still
+fires, but it is a degraded loop (no routing, no cache, no compaction — context
+grows until the provider refuses it), not a supported standalone mode.
 
 ## Why not just use ZeroClaw / OpenClaw?
 

--- a/README.md
+++ b/README.md
@@ -212,16 +212,6 @@ Every session gets a random hex ID. All input, output, tool calls, and results a
 [2026-02-16 16:30:04] ASST: Disk usage is at 72%, below threshold.
 ```
 
-## Context compaction
-
-When the message history exceeds `max_messages` (default 40), the agent:
-
-1. Sends old messages to the LLM for summarization
-2. Replaces them with the summary
-3. Keeps the last N raw messages intact
-
-No vector DB. No embeddings. One API call to compress context.
-
 ## Config reference
 
 | Key | Default | Description |
@@ -233,7 +223,6 @@ No vector DB. No embeddings. One API call to compress context.
 | `skills_dir` | `~/.subzeroclaw/skills` | Path to skill markdown files |
 | `log_dir` | `~/.subzeroclaw/logs` | Session log directory |
 | `max_turns` | 200 | Max tool-call loops per input |
-| `max_messages` | 40 | Trigger context compaction |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You write a skill as a markdown file. You point SubZeroClaw at it. It calls an L
 ~/.subzeroclaw/logs/<session>.txt   ← full I/O trace
 ```
 
-The agent reads the skill into its system prompt, receives input, and autonomously calls tools until the task is complete. When context gets full, it compacts old messages into a summary and keeps going.
+The agent reads the skill into its system prompt, receives input, and autonomously calls tools until the task is complete. When context grows, the router signals it and the agent seals the old turns **asynchronously** (append-only, in the background) — it never pauses to compact (see "Routing & compaction via unhardcoded").
 
 ## Quickstart
 
@@ -60,9 +60,14 @@ SubZeroClaw points its `endpoint` at [**unhardcoded**](https://github.com/genlay
   to the peer that already holds its prompt-cache prefix (SubZeroClaw sends a
   per-run `session` id for that affinity), e.g.
   `{"model":"policy:auto","policy_ir":[ "policy", … cache_hot affinity … ]}`.
-- **Compaction** — the router seals the aged context append-only and signals when
-  (an `x_router.compact` flag on the response), so the agent never re-summarizes
-  in C. *(The agent-side wiring lands in the companion change.)*
+- **Compaction** — when the router signals context pressure (an `x_router.compact`
+  flag on the response), SubZeroClaw fires an append-only seal at the router's
+  `/v1/compact` **in the background** and keeps taking turns; when the sealed block
+  lands it splices it in *ahead* of the turns that arrived meanwhile. Compaction is
+  asynchronous — no turn is ever blocked, the prompt-cache prefix is never
+  rewritten, and you never see a pause. The seal routing + how many recent turns to
+  keep verbatim ride in `SUBZEROCLAW_COMPACT_EXTRA` (the second JSON), e.g.
+  `{"keep_recent":8,"policy_ir":[ "policy", … cheap summariser … ]}`.
 
 This is SubZeroClaw being *more* itself: the loop, the shell, the skill — plus a
 single MIT dependency for the substrate concerns. Point `endpoint` at a plain
@@ -147,10 +152,13 @@ Environment variables override the config file:
 ```
 SUBZEROCLAW_API_KEY
 SUBZEROCLAW_ENDPOINT
-SUBZEROCLAW_REQUEST_EXTRA   # JSON merged into every request body. Carries the model
-                           #   ({"model":"..."}); against an unhardcoded router it carries
+SUBZEROCLAW_REQUEST_EXTRA   # the LOOP JSON, merged into every request body. Carries the
+                           #   model ({"model":"..."}); against an unhardcoded router it carries
                            #   the routing policy too ({"model":"policy:auto","policy_ir":[...]}).
                            #   On a key collision the override wins.
+SUBZEROCLAW_COMPACT_EXTRA  # the COMPACTION JSON. When set, an x_router.compact signal triggers
+                           #   an async append-only seal at the router's /v1/compact; this carries
+                           #   keep_recent + the cheap summariser policy_ir. Unset -> no compaction.
 ```
 
 ## Usage
@@ -215,7 +223,8 @@ No vector DB. No embeddings. One API call to compress context.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `api_key` | (required) | OpenRouter (or unhardcoded) API key |
-| `request_extra` | (none) | JSON merged into every request body — carries the `model`, and against an unhardcoded router the routing `policy_ir` |
+| `request_extra` | (none) | the loop JSON merged into every request body — carries the `model`, and against an unhardcoded router the routing `policy_ir` |
+| `compact_extra` | (none) | the compaction JSON — `keep_recent` + the cheap summariser `policy_ir`; unset disables compaction |
 | `endpoint` | `https://openrouter.ai/api/v1/chat/completions` | API endpoint (point it at an unhardcoded router for routing/cache/compaction) |
 | `skills_dir` | `~/.subzeroclaw/skills` | Path to skill markdown files |
 | `log_dir` | `~/.subzeroclaw/logs` | Session log directory |

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -16,15 +16,16 @@
 #define MAX_EXTRA  8192   /* request_extra: an operator-supplied JSON body override */
 
 typedef struct {
-    char api_key[MAX_VALUE], model[MAX_VALUE], endpoint[MAX_VALUE];
+    char api_key[MAX_VALUE], endpoint[MAX_VALUE];
     char skills_dir[MAX_PATH], log_dir[MAX_PATH];
     char request_extra[MAX_EXTRA];
+    char session[MAX_VALUE];   /* runtime per-run id (sid); sent so the router can
+                                  keep this conversation pinned to its cache-hot peer */
     int  max_turns, max_messages;
 } Config;
 
 static void config_parse_line(Config *cfg, const char *key, const char *val) {
     if      (!strcmp(key, "api_key"))      snprintf(cfg->api_key,    MAX_VALUE, "%s", val);
-    else if (!strcmp(key, "model"))        snprintf(cfg->model,      MAX_VALUE, "%s", val);
     else if (!strcmp(key, "endpoint"))     snprintf(cfg->endpoint,   MAX_VALUE, "%s", val);
     else if (!strcmp(key, "skills_dir"))   snprintf(cfg->skills_dir, MAX_PATH,  "%s", val);
     else if (!strcmp(key, "log_dir"))      snprintf(cfg->log_dir,    MAX_PATH,  "%s", val);
@@ -38,7 +39,6 @@ int config_load(Config *cfg) {
     if (!home) home = ".";
     memset(cfg, 0, sizeof(*cfg));
     snprintf(cfg->endpoint,   MAX_VALUE, "https://openrouter.ai/api/v1/chat/completions");
-    snprintf(cfg->model,      MAX_VALUE, "minimax/minimax-m2.5");
     snprintf(cfg->skills_dir, MAX_PATH,  "%s/.subzeroclaw/skills", home);
     snprintf(cfg->log_dir,    MAX_PATH,  "%s/.subzeroclaw/logs", home);
     cfg->max_turns = 200; cfg->max_messages = 40;
@@ -65,7 +65,6 @@ int config_load(Config *cfg) {
     }
     char *v;
     if ((v = getenv("SUBZEROCLAW_API_KEY")))  snprintf(cfg->api_key,  MAX_VALUE, "%s", v);
-    if ((v = getenv("SUBZEROCLAW_MODEL")))    snprintf(cfg->model,    MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_ENDPOINT"))) snprintf(cfg->endpoint, MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_REQUEST_EXTRA"))) snprintf(cfg->request_extra, MAX_EXTRA, "%s", v);
     if (!cfg->api_key[0]) { fprintf(stderr, "error: no api_key\n"); return -1; }
@@ -81,7 +80,7 @@ int config_load(Config *cfg) {
        cfg, so requests are unaffected. */
     {
         static const char *const secret_vars[] = {
-            "SUBZEROCLAW_API_KEY", "SUBZEROCLAW_MODEL",
+            "SUBZEROCLAW_API_KEY",
             "SUBZEROCLAW_ENDPOINT", "SUBZEROCLAW_REQUEST_EXTRA"
         };
         for (size_t i = 0; i < sizeof(secret_vars) / sizeof(secret_vars[0]); i++) {
@@ -226,13 +225,18 @@ static void response_free(Response *r) {
 /* references avoid copying the full message array */
 static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
     cJSON *req = cJSON_CreateObject();
-    cJSON_AddStringToObject(req, "model", cfg->model);
+    /* Session id (if any): sent so the router can keep this conversation pinned to
+       the peer that already holds its prompt-cache prefix (cache_hot). */
+    if (cfg->session[0]) cJSON_AddStringToObject(req, "session", cfg->session);
 
-    /* Optional operator-supplied request-body override (SUBZEROCLAW_REQUEST_EXTRA):
-       a JSON object whose top-level keys are merged in. Empty/unset → unchanged;
-       malformed → ignored; on a key collision the override wins. Applied before
-       messages/tools so it can replace `model` and add params (temperature, …)
-       without colliding with the reference items below. */
+    /* The model is NOT hardcoded by the agent. It rides in the operator's
+       SUBZEROCLAW_REQUEST_EXTRA — "model":"policy:auto" plus a "policy_ir" to let
+       the unhardcoded router decide, or a concrete model for a direct provider.
+       SUBZEROCLAW_REQUEST_EXTRA is a JSON object whose top-level keys are merged
+       in: empty/unset → unchanged; malformed → ignored; on a key collision the
+       override wins. Applied before messages/tools so it can add `model`,
+       `policy_ir`, params (temperature, …) without colliding with the reference
+       items below. */
     if (cfg->request_extra[0]) {
         cJSON *extra = cJSON_Parse(cfg->request_extra);
         if (extra && cJSON_IsObject(extra)) {
@@ -409,7 +413,7 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
 
     for (int turn = 1; turn <= cfg->max_turns; turn++) {
         compact_messages(cfg, msgs, log);
-        fprintf(stderr, "[%d] %s...\n", turn, cfg->model);
+        fprintf(stderr, "[%d] ...\n", turn);
         char *rb = llm_chat(cfg, msgs, tools);
         if (!rb) return -1;
         Response resp;
@@ -480,6 +484,7 @@ int main(int argc, char **argv) {
                   b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]);
           fclose(ur); }
       if (!sid[0]) snprintf(sid, sizeof(sid), "%lx%x", (long)time(NULL), getpid()); }
+    snprintf(cfg.session, MAX_VALUE, "%s", sid);  /* sent on every request for cache affinity */
     mkdirp(cfg.log_dir);
     char lp[600]; snprintf(lp, sizeof(lp), "%s/%s.txt", cfg.log_dir, sid);
     FILE *log = fopen(lp, "a");
@@ -489,7 +494,7 @@ int main(int argc, char **argv) {
     cJSON_AddItemToArray(msgs, make_msg("system", sysprompt));
     cJSON *tools = cJSON_Parse(TOOLS_JSON);
     int rc = 0;
-    fprintf(stderr, "subzeroclaw · %s · %s\n", cfg.model, sid);
+    fprintf(stderr, "subzeroclaw · %s\n", sid);
 
     if (argc > 1) {
         char input[4096], *p = input, *end = input + sizeof(input) - 1;

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -18,10 +18,11 @@
 typedef struct {
     char api_key[MAX_VALUE], endpoint[MAX_VALUE];
     char skills_dir[MAX_PATH], log_dir[MAX_PATH];
-    char request_extra[MAX_EXTRA];
+    char request_extra[MAX_EXTRA];   /* the loop JSON: model + routing policy_ir */
+    char compact_extra[MAX_EXTRA];   /* the compaction JSON: keep_recent + seal policy_ir */
     char session[MAX_VALUE];   /* runtime per-run id (sid); sent so the router can
                                   keep this conversation pinned to its cache-hot peer */
-    int  max_turns, max_messages;
+    int  max_turns;
 } Config;
 
 static void config_parse_line(Config *cfg, const char *key, const char *val) {
@@ -30,8 +31,8 @@ static void config_parse_line(Config *cfg, const char *key, const char *val) {
     else if (!strcmp(key, "skills_dir"))   snprintf(cfg->skills_dir, MAX_PATH,  "%s", val);
     else if (!strcmp(key, "log_dir"))      snprintf(cfg->log_dir,    MAX_PATH,  "%s", val);
     else if (!strcmp(key, "request_extra")) snprintf(cfg->request_extra, MAX_EXTRA, "%s", val);
+    else if (!strcmp(key, "compact_extra")) snprintf(cfg->compact_extra, MAX_EXTRA, "%s", val);
     else if (!strcmp(key, "max_turns"))    cfg->max_turns    = atoi(val);
-    else if (!strcmp(key, "max_messages")) cfg->max_messages = atoi(val);
 }
 
 int config_load(Config *cfg) {
@@ -41,7 +42,7 @@ int config_load(Config *cfg) {
     snprintf(cfg->endpoint,   MAX_VALUE, "https://openrouter.ai/api/v1/chat/completions");
     snprintf(cfg->skills_dir, MAX_PATH,  "%s/.subzeroclaw/skills", home);
     snprintf(cfg->log_dir,    MAX_PATH,  "%s/.subzeroclaw/logs", home);
-    cfg->max_turns = 200; cfg->max_messages = 40;
+    cfg->max_turns = 200;
 
     char path[MAX_PATH];
     snprintf(path, MAX_PATH, "%s/.subzeroclaw/config", home);
@@ -67,6 +68,7 @@ int config_load(Config *cfg) {
     if ((v = getenv("SUBZEROCLAW_API_KEY")))  snprintf(cfg->api_key,  MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_ENDPOINT"))) snprintf(cfg->endpoint, MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_REQUEST_EXTRA"))) snprintf(cfg->request_extra, MAX_EXTRA, "%s", v);
+    if ((v = getenv("SUBZEROCLAW_COMPACT_EXTRA"))) snprintf(cfg->compact_extra, MAX_EXTRA, "%s", v);
     if (!cfg->api_key[0]) { fprintf(stderr, "error: no api_key\n"); return -1; }
 
     /* Scrub the provider config from our own environment now that it lives in cfg.
@@ -80,8 +82,8 @@ int config_load(Config *cfg) {
        cfg, so requests are unaffected. */
     {
         static const char *const secret_vars[] = {
-            "SUBZEROCLAW_API_KEY",
-            "SUBZEROCLAW_ENDPOINT", "SUBZEROCLAW_REQUEST_EXTRA"
+            "SUBZEROCLAW_API_KEY", "SUBZEROCLAW_ENDPOINT",
+            "SUBZEROCLAW_REQUEST_EXTRA", "SUBZEROCLAW_COMPACT_EXTRA"
         };
         for (size_t i = 0; i < sizeof(secret_vars) / sizeof(secret_vars[0]); i++) {
             char *p = getenv(secret_vars[i]);
@@ -215,6 +217,7 @@ char *agent_build_system_prompt(const char *skills_dir) {
 typedef struct {
     char *finish_reason, *text;
     cJSON *tool_calls, *msg;
+    int compact;   /* router asked us to seal context (x_router.compact) */
 } Response;
 
 static void response_free(Response *r) {
@@ -302,6 +305,8 @@ static int parse_response(const char *body, Response *out) {
     cJSON *ct = cJSON_GetObjectItem(out->msg, "content");
     out->text = (ct && cJSON_IsString(ct)) ? ct->valuestring : NULL;
     out->tool_calls = cJSON_GetObjectItem(out->msg, "tool_calls");
+    cJSON *xr = cJSON_GetObjectItem(root, "x_router");
+    out->compact = xr && cJSON_IsTrue(cJSON_GetObjectItem(xr, "compact"));
     cJSON_Delete(root);
     return 0;
 }
@@ -313,65 +318,91 @@ static cJSON *make_msg(const char *role, const char *content) {
     return m;
 }
 
-static int compact_messages(const Config *cfg, cJSON *msgs, FILE *log) {
-    int total = cJSON_GetArraySize(msgs);
-    if (total <= cfg->max_messages) return 0;
-    fprintf(stderr, "[compact] %d msgs, summarizing\n", total);
-    log_write(log, "SYS", "compacting context");
+/* Context compaction is no longer summarized in C. The router's /v1/compact seals
+   the aged middle append-only (the frozen prefix + recent tail stay byte-identical,
+   so the prompt-cache prefix is never invalidated). We run it ASYNCHRONOUSLY: fire
+   the seal in the background, keep doing turns, and splice the result in when it
+   lands — so a turn is never blocked and nobody perceives a compaction pause. */
 
-    /* build text digest — keep user/assistant in full, trim only tool outputs */
-    size_t cap = 512000, len = 0;
-    char *convo = malloc(cap);
-    convo[0] = '\0';
-    cJSON *m = NULL;
-    cJSON_ArrayForEach(m, msgs) {
-        if (len + 256 >= cap) break;
-        cJSON *role = cJSON_GetObjectItem(m, "role");
-        cJSON *ct = cJSON_GetObjectItem(m, "content");
-        if (!role || !cJSON_IsString(role) || !ct || !cJSON_IsString(ct)) continue;
-        const char *r = role->valuestring, *c = ct->valuestring;
-        size_t clen = strlen(c);
-        if (!strcmp(r, "tool") && clen > 2000) {
-            /* tool outputs: first 1000 + ... + last 1000 */
-            len += snprintf(convo + len, cap - len, "tool: %.*s\n...[%zu bytes trimmed]...\n%s\n",
-                1000, c, clen - 2000, c + clen - 1000);
-        } else {
-            len += snprintf(convo + len, cap - len, "%s: %s\n", r, c);
+static char *read_file(const char *path) {
+    FILE *f = fopen(path, "r"); if (!f) return NULL;
+    size_t cap = 65536, len = 0, n;
+    char *buf = malloc(cap);
+    while (buf && (n = fread(buf + len, 1, cap - len - 1, f)) > 0) {
+        len += n;
+        if (len + 1 >= cap) { cap *= 2; char *nb = realloc(buf, cap);
+            if (!nb) { free(buf); buf = NULL; break; } buf = nb; }
+    }
+    if (buf) buf[len] = '\0';
+    fclose(f);
+    return buf;
+}
+
+/* The /v1/compact URL, derived from the chat endpoint. */
+static void compact_url(const Config *cfg, char *out, size_t sz) {
+    const char *e = cfg->endpoint, *p = strstr(e, "/chat/completions");
+    if (p) snprintf(out, sz, "%.*s/compact", (int)(p - e), e);
+    else   snprintf(out, sz, "%s/compact", e);
+}
+
+/* Fire an append-only seal of the current `msgs` in the BACKGROUND: POST to the
+   router's /v1/compact, atomically writing the spliced array to `res_path`. The
+   seal routing + keep_recent ride in SUBZEROCLAW_COMPACT_EXTRA. Returns 0 if
+   launched; the agent keeps looping and picks up the result on a later turn. */
+static int compact_fire(const Config *cfg, cJSON *msgs, char *res_path, size_t res_sz) {
+    cJSON *req = cJSON_CreateObject();
+    if (cfg->compact_extra[0]) {            /* keep_recent / policy_ir / max_tokens */
+        cJSON *extra = cJSON_Parse(cfg->compact_extra);
+        if (extra && cJSON_IsObject(extra)) {
+            cJSON *it = NULL;
+            cJSON_ArrayForEach(it, extra) {
+                cJSON *dup = cJSON_Duplicate(it, 1);
+                if (dup) cJSON_AddItemToObject(req, it->string, dup);
+            }
         }
+        if (extra) cJSON_Delete(extra);
     }
-    size_t plen = len + 128;
-    char *prompt = malloc(plen);
-    snprintf(prompt, plen, "Summarize this conversation. Keep all facts, file paths, "
-        "commands, and decisions. Be concise.\n\n%s", convo);
-    free(convo);
+    cJSON_AddItemReferenceToObject(req, "messages", msgs);
+    char *body = cJSON_PrintUnformatted(req);
+    cJSON_DetachItemFromObject(req, "messages");
+    cJSON_Delete(req);
+    if (!body) return -1;
 
-    cJSON *sm = cJSON_CreateArray();
-    cJSON_AddItemToArray(sm, make_msg("user", prompt)); free(prompt);
-    char *rb = llm_chat(cfg, sm, NULL);
-    cJSON_Delete(sm);
-    if (!rb) return -1;
+    char body_path[64], hdr_path[64];
+    if (write_temp("cbody", body, body_path, sizeof(body_path)) < 0) { free(body); return -1; }
+    free(body);
+    char hdr[MAX_VALUE + 64];
+    snprintf(hdr, sizeof(hdr), "-H \"Authorization: Bearer %s\"", cfg->api_key);
+    if (write_temp("chdr", hdr, hdr_path, sizeof(hdr_path)) < 0) { unlink(body_path); return -1; }
 
-    Response resp;
-    if (parse_response(rb, &resp) != 0 || !resp.text) { free(rb); response_free(&resp); return -1; }
-    char *summary = strdup(resp.text); free(rb); response_free(&resp);
-    log_write(log, "COMPACT", summary);
+    char url[MAX_VALUE + 16]; compact_url(cfg, url, sizeof(url));
+    snprintf(res_path, res_sz, "/tmp/.szc_cres_%d", (int)getpid());
+    /* atomic: write .tmp then rename, so res_path appears only when complete; the
+       subshell cleans its own temp files and detaches (&) so this returns at once. */
+    char cmd[2048 + MAX_VALUE];
+    snprintf(cmd, sizeof(cmd),
+        "( curl -s -m 120 -K '%s' -H 'Content-Type: application/json' -d @'%s' '%s' "
+        "-o '%s.tmp' && mv '%s.tmp' '%s' ; rm -f '%s' '%s' ) >/dev/null 2>&1 &",
+        hdr_path, body_path, url, res_path, res_path, res_path, body_path, hdr_path);
+    return system(cmd) == 0 ? 0 : -1;
+}
 
-    /* keep last ~10 msgs, but skip orphaned tool msgs at the boundary
-       (their tool_call_ids reference deleted assistant msgs → API rejects) */
-    int start = total - 10;
-    if (start < 1) start = 1;
-    while (start < total - 1) {
-        cJSON *r = cJSON_GetObjectItem(cJSON_GetArrayItem(msgs, start), "role");
-        if (!r || strcmp(r->valuestring, "tool") != 0) break;
-        start++;
+/* A background seal finished: replace the `snapshot_len` compacted messages with
+   the sealed view, keeping every turn that arrived while it ran (append-only ⇒
+   conflict-free). */
+static void compact_splice(cJSON *msgs, int snapshot_len, const char *res_path, FILE *log) {
+    char *buf = read_file(res_path);
+    unlink(res_path);
+    if (!buf) return;
+    cJSON *root = cJSON_Parse(buf); free(buf);
+    cJSON *sp = root ? cJSON_GetObjectItem(root, "messages") : NULL;
+    if (sp && cJSON_IsArray(sp) && cJSON_GetArraySize(msgs) >= snapshot_len) {
+        for (int i = 0; i < snapshot_len; i++) cJSON_DeleteItemFromArray(msgs, 0);
+        for (int i = cJSON_GetArraySize(sp) - 1; i >= 0; i--)
+            cJSON_InsertItemInArray(msgs, 0, cJSON_Duplicate(cJSON_GetArrayItem(sp, i), 1));
+        log_write(log, "SYS", "context compacted (append-only, async)");
     }
-
-    for (int i = start - 1; i >= 1; i--)
-        cJSON_DeleteItemFromArray(msgs, i);
-    cJSON_InsertItemInArray(msgs, 1, make_msg("user", "[Summary of previous context]"));
-    cJSON_InsertItemInArray(msgs, 2, make_msg("assistant", summary));
-    free(summary);
-    return 0;
+    if (root) cJSON_Delete(root);
 }
 
 static void process_tool_calls(cJSON *tool_calls, cJSON *msgs, FILE *log) {
@@ -411,8 +442,15 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
     cJSON_AddItemToArray(msgs, make_msg("user", input));
     log_write(log, "USER", input);
 
+    int compacting = 0, snapshot_len = 0;
+    char compact_res[80] = {0};
     for (int turn = 1; turn <= cfg->max_turns; turn++) {
-        compact_messages(cfg, msgs, log);
+        /* a background seal finished while we kept working? splice it in now —
+           append-only, so it never collides with the turns added meanwhile. */
+        if (compacting && access(compact_res, F_OK) == 0) {
+            compact_splice(msgs, snapshot_len, compact_res, log);
+            compacting = 0;
+        }
         fprintf(stderr, "[%d] ...\n", turn);
         char *rb = llm_chat(cfg, msgs, tools);
         if (!rb) return -1;
@@ -421,16 +459,23 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
         free(rb);
         cJSON_AddItemToArray(msgs, resp.msg); resp.msg = NULL;
 
+        /* router signalled context pressure: seal in the background and keep going */
+        if (resp.compact && !compacting && cfg->compact_extra[0]) {
+            snapshot_len = cJSON_GetArraySize(msgs);
+            if (compact_fire(cfg, msgs, compact_res, sizeof(compact_res)) == 0)
+                compacting = 1;
+        }
+
         if (!strcmp(resp.finish_reason, "stop")) {
             if (resp.text) { printf("%s\n", resp.text); log_write(log, "ASST", resp.text); }
-            free(resp.finish_reason); return 0;
+            response_free(&resp); return 0;   /* msg already transferred; frees finish_reason */
         }
         if (!strcmp(resp.finish_reason, "tool_calls") && resp.tool_calls) {
             process_tool_calls(resp.tool_calls, msgs, log);
-            free(resp.finish_reason); continue;
+            response_free(&resp); continue;
         }
         if (resp.text) { printf("%s\n", resp.text); log_write(log, "ASST", resp.text); }
-        free(resp.finish_reason); return 0;
+        response_free(&resp); return 0;
     }
     fprintf(stderr, "error: max turns (%d) reached\n", cfg->max_turns);
     return -1;

--- a/src/test.c
+++ b/src/test.c
@@ -416,6 +416,49 @@ static void test_config_scrubs_env(void) {
 
 /* ======== MAIN ======== */
 
+static void test_parse_compact_flag(void) {
+    TEST("parse_response: reads x_router.compact");
+    Response r1, r2;
+    int ok1 = parse_response(
+        "{\"choices\":[{\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"hi\"}}],"
+        "\"x_router\":{\"compact\":true}}", &r1) == 0;
+    int ok2 = parse_response(
+        "{\"choices\":[{\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"hi\"}}]}",
+        &r2) == 0;
+    if (ok1 && ok2 && r1.compact == 1 && r2.compact == 0) PASS();
+    else FAIL("compact flag mismatch");
+    if (ok1) response_free(&r1);
+    if (ok2) response_free(&r2);
+}
+
+static void test_compact_splice(void) {
+    TEST("compact_splice: append-only seal keeps post-snapshot turns");
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("system", "sys"));     /* 0 */
+    cJSON_AddItemToArray(msgs, make_msg("user", "u0"));        /* 1 */
+    cJSON_AddItemToArray(msgs, make_msg("assistant", "a0"));   /* 2 */
+    cJSON_AddItemToArray(msgs, make_msg("user", "u1"));        /* 3 */
+    cJSON_AddItemToArray(msgs, make_msg("assistant", "a1"));   /* 4  -> snapshot_len = 5 */
+    cJSON_AddItemToArray(msgs, make_msg("user", "u2"));        /* 5  arrived while sealing */
+    cJSON_AddItemToArray(msgs, make_msg("assistant", "a2"));   /* 6  */
+    char path[64];
+    write_temp("testcres",
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"sys\"},"
+        "{\"role\":\"system\",\"content\":\"SEALED\"}],\"compacted\":true}",
+        path, sizeof(path));
+    compact_splice(msgs, 5, path, NULL);   /* consumes + unlinks path */
+    int n = cJSON_GetArraySize(msgs);
+    cJSON *m1 = cJSON_GetArrayItem(msgs, 1), *last = cJSON_GetArrayItem(msgs, n - 1);
+    cJSON *c1 = m1 ? cJSON_GetObjectItem(m1, "content") : NULL;
+    cJSON *cl = last ? cJSON_GetObjectItem(last, "content") : NULL;
+    if (n == 4 &&                                       /* sys + SEALED + u2 + a2 */
+        c1 && !strcmp(c1->valuestring, "SEALED") &&
+        cl && !strcmp(cl->valuestring, "a2"))           /* post-snapshot turns kept */
+        PASS();
+    else FAIL("splice result wrong");
+    cJSON_Delete(msgs);
+}
+
 int main(void) {
     printf("\n  SubZeroClaw test suite\n");
     printf("  ═══════════════════════════════════════════\n\n");
@@ -441,6 +484,8 @@ int main(void) {
     test_build_request_extra_merge();
     test_build_request_extra_empty();
     test_build_request_extra_garbage();
+    test_parse_compact_flag();
+    test_compact_splice();
     test_full_tool_dispatch();
     test_system_prompt();
     test_skills_loading();

--- a/src/test.c
+++ b/src/test.c
@@ -279,10 +279,10 @@ static void test_skills_loading(void) {
 /* ======== REQUEST BUILDING TESTS ======== */
 
 static void test_build_request(void) {
-    TEST("build_request: JSON structure");
+    TEST("build_request: JSON structure + session, no hardcoded model");
     Config cfg;
     memset(&cfg, 0, sizeof(cfg));
-    snprintf(cfg.model, MAX_VALUE, "test-model");
+    snprintf(cfg.session, MAX_VALUE, "sid-123");
     cJSON *msgs = cJSON_CreateArray();
     cJSON_AddItemToArray(msgs, make_msg("system", "hello"));
     cJSON *tools = cJSON_Parse(TOOLS_JSON);
@@ -290,10 +290,12 @@ static void test_build_request(void) {
     assert(json);
     cJSON *req = cJSON_Parse(json);
     assert(req);
+    cJSON *session = cJSON_GetObjectItem(req, "session");
     cJSON *model = cJSON_GetObjectItem(req, "model");
     cJSON *m = cJSON_GetObjectItem(req, "messages");
     cJSON *t = cJSON_GetObjectItem(req, "tools");
-    if (model && strcmp(model->valuestring, "test-model") == 0 &&
+    if (session && strcmp(session->valuestring, "sid-123") == 0 &&
+        !model &&                       /* the agent ships no model; it rides in REQUEST_EXTRA */
         m && cJSON_GetArraySize(m) == 1 &&
         t && cJSON_GetArraySize(t) == 1)
         PASS();
@@ -306,7 +308,6 @@ static void test_build_request(void) {
 static void test_build_request_extra_merge(void) {
     TEST("build_request: REQUEST_EXTRA merges, override wins");
     Config cfg; memset(&cfg, 0, sizeof(cfg));
-    snprintf(cfg.model, MAX_VALUE, "base-model");
     snprintf(cfg.request_extra, MAX_EXTRA,
         "{\"temperature\": 0.5, \"model\": \"override-model\"}");
     cJSON *msgs = cJSON_CreateArray();
@@ -331,12 +332,10 @@ static void test_build_request_extra_merge(void) {
 static void test_build_request_extra_empty(void) {
     TEST("build_request: empty REQUEST_EXTRA leaves body unchanged");
     Config cfg; memset(&cfg, 0, sizeof(cfg));
-    snprintf(cfg.model, MAX_VALUE, "m");
     cJSON *msgs = cJSON_CreateArray();
     char *json = build_request(&cfg, msgs, NULL);
     cJSON *req = cJSON_Parse(json); assert(req);
-    if (cJSON_GetArraySize(req) == 2 &&        /* exactly model + messages */
-        cJSON_GetObjectItem(req, "model") &&
+    if (cJSON_GetArraySize(req) == 1 &&        /* exactly messages (no session, no model) */
         cJSON_GetObjectItem(req, "messages"))
         PASS();
     else FAIL("body changed when unset");
@@ -346,12 +345,11 @@ static void test_build_request_extra_empty(void) {
 static void test_build_request_extra_garbage(void) {
     TEST("build_request: malformed REQUEST_EXTRA ignored");
     Config cfg; memset(&cfg, 0, sizeof(cfg));
-    snprintf(cfg.model, MAX_VALUE, "m");
     snprintf(cfg.request_extra, MAX_EXTRA, "{not valid json");
     cJSON *msgs = cJSON_CreateArray();
     char *json = build_request(&cfg, msgs, NULL);
     cJSON *req = cJSON_Parse(json);            /* request must still be valid */
-    if (req && cJSON_GetObjectItem(req, "model") && cJSON_GetObjectItem(req, "messages"))
+    if (req && cJSON_GetObjectItem(req, "messages"))
         PASS();
     else FAIL("garbage broke the request");
     if (req) cJSON_Delete(req); free(json); cJSON_Delete(msgs);
@@ -362,7 +360,6 @@ static void test_build_request_extra_garbage(void) {
 static void test_config_no_key(void) {
     TEST("config: fails without API key");
     unsetenv("SUBZEROCLAW_API_KEY");
-    unsetenv("SUBZEROCLAW_MODEL");
     unsetenv("SUBZEROCLAW_ENDPOINT");
     Config cfg;
     /* point config at nonexistent file so file parsing is skipped */
@@ -394,7 +391,6 @@ static void test_config_scrubs_env(void) {
     char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
     setenv("HOME", "/tmp/szc_no_config", 1); /* skip any real config file */
     setenv("SUBZEROCLAW_API_KEY", "sk-test-scrub", 1);
-    setenv("SUBZEROCLAW_MODEL", "test/model", 1);
     setenv("SUBZEROCLAW_ENDPOINT", "https://test.example/v1/chat", 1);
     setenv("SUBZEROCLAW_REQUEST_EXTRA", "{\"temperature\":0}", 1);
     Config cfg;
@@ -405,13 +401,11 @@ static void test_config_scrubs_env(void) {
     /* values survive in cfg, so requests are unaffected... */
     int cfg_ok = rc == 0 &&
         strcmp(cfg.api_key, "sk-test-scrub") == 0 &&
-        strcmp(cfg.model, "test/model") == 0 &&
         strcmp(cfg.endpoint, "https://test.example/v1/chat") == 0 &&
         strcmp(cfg.request_extra, "{\"temperature\":0}") == 0;
     /* ...but are gone from the environment the shell tool inherits */
     int env_scrubbed =
         getenv("SUBZEROCLAW_API_KEY") == NULL &&
-        getenv("SUBZEROCLAW_MODEL") == NULL &&
         getenv("SUBZEROCLAW_ENDPOINT") == NULL &&
         getenv("SUBZEROCLAW_REQUEST_EXTRA") == NULL;
 


### PR DESCRIPTION
SubZeroClaw stops hardcoding the model. Routing (which provider/model, with
prompt-cache affinity) belongs to the substrate, not the agent — so the model
now rides in the operator's SUBZEROCLAW_REQUEST_EXTRA (the generic body-override
channel, §"new body field → REQUEST_EXTRA"): "model":"..." for a direct provider,
or "model":"policy:auto" + "policy_ir":[…] against an unhardcoded router (MIT).

- Deleted cfg.model, the "model" config key, SUBZEROCLAW_MODEL, the hardcoded
  minimax default, and the model line in build_request. Net-negative C; the agent
  ships no model opinion.
- build_request now sends "session": <sid> (the per-run id already generated for
  the log) so the router can keep this conversation pinned to its cache-hot peer.
- README: model moves to request_extra; new "Routing & compaction via unhardcoded"
  section documents the MIT runtime dependency and the two-JSON model.
- test.c updated (CONTRIBUTING): build_request now asserts session present + no
  hardcoded model; the env-scrub and merge tests drop the model references.

Ergonomic note for review: a standalone `model = "x"` config line is no longer a
key — it becomes `request_extra = "{\"model\":\"x\"}"`. Deliberate per the design
(model via the generic channel); flag if you'd rather keep a `model=` shortcut.

Build clean (-Wall -Wextra); make test 27/0.

---

## Plus: async append-only compaction (was PR6, folded in)

The second half of the transformation — context compaction also leaves the C and
becomes a second JSON + a router call:

- Deleted `compact_messages` (~60 lines of in-C summarization + message surgery).
- On the router's `x_router.compact` signal, fire an append-only seal at
  `/v1/compact` **in the background** (a detached curl, atomic result) and keep
  taking turns; splice the sealed block in *ahead* of the turns that arrived
  meanwhile. Append-only ⇒ conflict-free; **autocompacting** — no turn blocks, no
  pause is ever perceived.
- Threadless on purpose: async via a background process (`popen`/`system`), not a
  pthread — "the adapter is the shell".
- New `SUBZEROCLAW_COMPACT_EXTRA` (the compaction JSON); deleted `max_messages`
  (the router owns the threshold now).
- Tests: `parse_response` reads the flag; `compact_splice` keeps post-snapshot
  turns. README updated. Build clean; `make test` 29/0.

Net: SubZeroClaw is now an unhardcoded client — model, routing and compaction all
expressed as two JSONs, the in-C model/summarization logic gone. New runtime
dependency: an [unhardcoded](https://github.com/genlayerlabs/unhardcoded) router
(MIT) for the routing/cache/compaction features; point `endpoint` at a plain
provider to run standalone as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Configuration Changes**
  * Removed standalone provider `model` configuration; `model` (and related request options) are now supplied via `request_extra`.
  * Added per-run session identifiers sent with each request.
  * Added `compact_extra` support for router-driven context compaction.

* **New Features**
  * Router-driven message compaction with asynchronous sealing and splicing of compacted context.

* **Documentation**
  * Updated environment-variable documentation, examples, and troubleshooting to reflect the new `request_extra`-based workflow.

* **Tests**
  * Updated request/config expectations and added coverage for compact-flag parsing and compact splicing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->