### PR TITLE
fix: honor SUBZEROCLAW_SKILLS env so swarm agents load their per-agent skill

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -67,6 +67,10 @@ int config_load(Config *cfg) {
     char *v;
     if ((v = getenv("SUBZEROCLAW_API_KEY")))  snprintf(cfg->api_key,  MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_ENDPOINT"))) snprintf(cfg->endpoint, MAX_VALUE, "%s", v);
+    /* Per-agent skills dir from the orchestrator (genswarms wrapper exports this).
+       Overrides the config-file / default ~/.subzeroclaw/skills so each agent in a
+       swarm loads its OWN configured skill instead of the host default. */
+    if ((v = getenv("SUBZEROCLAW_SKILLS"))) snprintf(cfg->skills_dir, MAX_PATH, "%s", v);
     if ((v = getenv("SUBZEROCLAW_REQUEST_EXTRA"))) snprintf(cfg->request_extra, MAX_EXTRA, "%s", v);
     if ((v = getenv("SUBZEROCLAW_COMPACT_EXTRA"))) snprintf(cfg->compact_extra, MAX_EXTRA, "%s", v);
     if (!cfg->api_key[0]) { fprintf(stderr, "error: no api_key\n"); return -1; }


### PR DESCRIPTION
## Problem

`config_load` reads `SUBZEROCLAW_API_KEY`, `SUBZEROCLAW_ENDPOINT`,
`SUBZEROCLAW_REQUEST_EXTRA` and `SUBZEROCLAW_COMPACT_EXTRA` from the
environment, but **not** `SUBZEROCLAW_SKILLS`. So the skills dir was always
the config-file value or the default `~/.subzeroclaw/skills`.

Orchestrators run one subzeroclaw per agent and point each at its own copied
skill dir via `SUBZEROCLAW_SKILLS` (the genswarms `szc-wrapper-fifo.sh`
exports exactly this). Because the var was ignored, **every agent loaded the
host default skills instead of its configured per-agent skill** — agents had
no task instructions and the system prompt was tiny.

## Fix

Read `SUBZEROCLAW_SKILLS` in `config_load`, overriding the config-file /
default value, consistent with the other env knobs.

## Impact verified

With the fix, swarm agents load their assigned skill: the system prompt grows
to the real skill size, which (a) gives agents their instructions and (b)
makes the prefix large and stable enough that the upstream router's prompt
cache engages — measured ~85% of input tokens served cached across a swarm
sharing one skill, and ~93% across a sustained multi-turn session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the skills directory via an environment variable, allowing a custom per-run skills location.
  * Falls back to the existing configured or default skills path when no override is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->