### PR TITLE
Discard tool-call rounds with no runnable command

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -491,7 +491,14 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
 
         /* Discard a tool-call round with no runnable command instead of recording it,
            so the model can't few-shot off its own malformed call and spiral (codex
-           emits empty arguments:"" under load). max_turns bounds a persistent loop. */
+           emits empty arguments:"" under load). max_turns bounds a persistent loop.
+
+           Integrity (object §3): the discard drops BOTH halves of the round
+           atomically — the assistant msg is never appended and process_tool_calls
+           never runs — so no tool_call_id is left orphaned (orphan → API 400). A
+           MIXED round (at least one call carries a command) is recorded instead,
+           and process_tool_calls then pairs every id with a `tool` reply, the empty
+           calls included (asserted by test_recorded_round_pairs_every_call). */
         if (!strcmp(resp.finish_reason, "tool_calls") && resp.tool_calls &&
             !round_has_command(resp.tool_calls)) {
             response_free(&resp);   /* discard: the empty call never enters history */

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -448,6 +448,25 @@ static void process_tool_calls(cJSON *tool_calls, cJSON *msgs, FILE *log) {
     }
 }
 
+/* Does this tool-call round contain at least one call with a usable (non-empty)
+   command? An all-empty round — every `arguments` empty/""/no "command"/blank
+   command — is a model hiccup (codex can emit arguments:"" under load) that we
+   refuse to record, so it can't poison the history and spiral. */
+static int round_has_command(cJSON *tool_calls) {
+    cJSON *tc = NULL;
+    cJSON_ArrayForEach(tc, tool_calls) {
+        cJSON *fn = cJSON_GetObjectItem(tc, "function");
+        cJSON *args = fn ? cJSON_GetObjectItem(fn, "arguments") : NULL;
+        if (!args || !cJSON_IsString(args)) continue;
+        cJSON *parsed = cJSON_Parse(args->valuestring);
+        cJSON *cmd = parsed ? cJSON_GetObjectItem(parsed, "command") : NULL;
+        int ok = cmd && cJSON_IsString(cmd) && cmd->valuestring[0] != '\0';
+        if (parsed) cJSON_Delete(parsed);
+        if (ok) return 1;
+    }
+    return 0;
+}
+
 static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
                      const char *input, FILE *log)
 {
@@ -469,6 +488,16 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
         Response resp;
         if (parse_response(rb, &resp) != 0) { free(rb); return -1; }
         free(rb);
+
+        /* Discard a tool-call round with no runnable command instead of recording it,
+           so the model can't few-shot off its own malformed call and spiral (codex
+           emits empty arguments:"" under load). max_turns bounds a persistent loop. */
+        if (!strcmp(resp.finish_reason, "tool_calls") && resp.tool_calls &&
+            !round_has_command(resp.tool_calls)) {
+            response_free(&resp);   /* discard: the empty call never enters history */
+            continue;
+        }
+
         cJSON_AddItemToArray(msgs, resp.msg); resp.msg = NULL;
 
         /* router signalled context pressure: seal in the background and keep going */

--- a/src/test.c
+++ b/src/test.c
@@ -288,6 +288,36 @@ static void test_round_has_command(void) {
     cJSON_Delete(blank); cJSON_Delete(none);
 }
 
+/* The kept path's integrity invariant (object §3): a round round_has_command lets
+   through (some call carries a command) is RECORDED, so process_tool_calls must
+   leave no orphan — every tool_call_id, the empty ones included, gets a matching
+   `tool` reply or the next request 400s. Asserted on a MIXED round, exactly the
+   shape the discard guard keeps. (round_has_command, the discard gate, is covered
+   above; here we pin the complementary record-and-pair half.) */
+static void test_recorded_round_pairs_every_call(void) {
+    TEST("recorded mixed round: every tool_call_id paired (no orphan)");
+    cJSON *tool_calls = cJSON_CreateArray();
+    cJSON_AddItemToArray(tool_calls, mk_tool_call("c1", ""));                          /* empty — kept because the round is mixed */
+    cJSON_AddItemToArray(tool_calls, mk_tool_call("c2", "{\"command\":\"echo ok\"}")); /* runnable */
+    cJSON *msgs = cJSON_CreateArray();
+    process_tool_calls(tool_calls, msgs, NULL);
+
+    int n = cJSON_GetArraySize(msgs), seen_c1 = 0, seen_c2 = 0, all_tool = 1;
+    for (int i = 0; i < n; i++) {
+        cJSON *m = cJSON_GetArrayItem(msgs, i);
+        cJSON *role = cJSON_GetObjectItem(m, "role");
+        cJSON *tcid = cJSON_GetObjectItem(m, "tool_call_id");
+        if (!role || !cJSON_IsString(role) || strcmp(role->valuestring, "tool")) all_tool = 0;
+        if (tcid && cJSON_IsString(tcid) && !strcmp(tcid->valuestring, "c1")) seen_c1 = 1;
+        if (tcid && cJSON_IsString(tcid) && !strcmp(tcid->valuestring, "c2")) seen_c2 = 1;
+    }
+    if (n == 2 && all_tool && seen_c1 && seen_c2) PASS();
+    else FAIL("orphaned tool_call_id (mixed round not fully paired)");
+
+    cJSON_Delete(tool_calls);
+    cJSON_Delete(msgs);
+}
+
 /* ======== SYSTEM PROMPT / SKILLS TEST ======== */
 
 static void test_system_prompt(void) {
@@ -526,6 +556,7 @@ int main(void) {
     test_compact_splice();
     test_full_tool_dispatch();
     test_round_has_command();
+    test_recorded_round_pairs_every_call();
     test_system_prompt();
     test_skills_loading();
     test_config_no_key();

--- a/src/test.c
+++ b/src/test.c
@@ -250,6 +250,44 @@ static void test_full_tool_dispatch(void) {
     free(result);
 }
 
+/* ======== MALFORMED TOOL-CALL TESTS ======== */
+
+/* Build one tool_call object: {"id":..,"function":{"name":"shell","arguments":<args_json>}}.
+   `arguments` is the model-supplied JSON string (subzeroclaw cJSON_Parses it). */
+static cJSON *mk_tool_call(const char *id, const char *args_json) {
+    cJSON *tc = cJSON_CreateObject();
+    cJSON_AddStringToObject(tc, "id", id);
+    cJSON *fn = cJSON_CreateObject();
+    cJSON_AddStringToObject(fn, "name", "shell");
+    cJSON_AddStringToObject(fn, "arguments", args_json);
+    cJSON_AddItemToObject(tc, "function", fn);
+    return tc;
+}
+
+static void test_round_has_command(void) {
+    TEST("round_has_command: real vs empty tool-call rounds");
+    cJSON *valid = cJSON_CreateArray();
+    cJSON_AddItemToArray(valid, mk_tool_call("c1", "{\"command\":\"echo hi\"}"));
+    cJSON *empty = cJSON_CreateArray();
+    cJSON_AddItemToArray(empty, mk_tool_call("c1", ""));                /* arguments "" — the real bug */
+    cJSON_AddItemToArray(empty, mk_tool_call("c2", "{}"));             /* no command key */
+    cJSON *mixed = cJSON_CreateArray();
+    cJSON_AddItemToArray(mixed, mk_tool_call("c1", ""));               /* empty */
+    cJSON_AddItemToArray(mixed, mk_tool_call("c2", "{\"command\":\"ls\"}")); /* valid */
+    cJSON *blank = cJSON_CreateArray();
+    cJSON_AddItemToArray(blank, mk_tool_call("c1", "{\"command\":\"\"}"));   /* blank command string */
+    cJSON *none = cJSON_CreateArray();
+    int ok =
+        round_has_command(valid) == 1 &&
+        round_has_command(empty) == 0 &&
+        round_has_command(mixed) == 1 &&
+        round_has_command(blank) == 0 &&
+        round_has_command(none)  == 0;
+    if (ok) PASS(); else FAIL("round_has_command mismatch");
+    cJSON_Delete(valid); cJSON_Delete(empty); cJSON_Delete(mixed);
+    cJSON_Delete(blank); cJSON_Delete(none);
+}
+
 /* ======== SYSTEM PROMPT / SKILLS TEST ======== */
 
 static void test_system_prompt(void) {
@@ -487,6 +525,7 @@ int main(void) {
     test_parse_compact_flag();
     test_compact_splice();
     test_full_tool_dispatch();
+    test_round_has_command();
     test_system_prompt();
     test_skills_loading();
     test_config_no_key();


### PR DESCRIPTION
## Problem

A model can emit a tool call with no usable command — the shell tool with no `command`, or empty `arguments:""` (codex does this under load). `agent_run` recorded that empty assistant turn, so the model few-shot off its own malformed call and re-emitted it every round until `max_turns`: burning LLM calls and never answering. We hit this in production.

## Fix

Discard a tool-call round with no runnable command (`round_has_command`) instead of recording it — the history stays clean, so the model retries fresh and a transient hiccup self-heals on the next round. `max_turns` still bounds a persistent loop. Nothing else in the loop changes.

## Tests

Unit-tests `round_has_command` (real / empty / mixed / blank-command / no-calls).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed tool-call responses by skipping tool-call rounds that don’t contain a usable, non-empty command.
  * Prevents recording and processing incomplete tool-call data that would otherwise lead to incorrect agent behavior.

* **Tests**
  * Added coverage for tool-call rounds with missing, empty, or blank `command` values.
  * Added tests to ensure tool-call processing still records expected tool reply pairs for mixed valid/invalid rounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->