### PR TITLE
docs: reconcile README + site with the runtime (~550 lines, deps, logo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="szc-logo.png" alt="SubZeroClaw" width="400">
+  <img src="logo.svg" alt="SubZeroClaw" width="180">
 </p>
 
 # SubZeroClaw
 
 > **WARNING: This software executes arbitrary shell commands with no safety checks, no confirmation prompts, no sandboxing, and no guardrails. The LLM decides what to run and the runtime runs it — `rm -rf /` included. There is nothing between the model's output and your system. If you don't understand what that means, do not use this. This is a bare agentic loop: execute the task, whatever it takes, nothing more, nothing less.**
 
-**~380 lines of C. 54KB binary. A skill-driven agentic daemon for edge hardware.**
+**~550 lines of C. 55KB binary. A skill-driven agentic daemon for edge hardware.**
 
 ```
 skill.md + LLM + shell + loop = autonomous agent
@@ -31,7 +31,7 @@ The agent reads the skill into its system prompt, receives input, and autonomous
 ```bash
 git clone https://github.com/genlayerlabs/subzeroclaw
 cd subzeroclaw
-make                          # builds the 54KB binary in ~0.5s
+make                          # builds the 55KB binary in ~0.5s
 
 mkdir -p ~/.subzeroclaw/skills
 cat > ~/.subzeroclaw/config << 'EOF'
@@ -89,11 +89,11 @@ SubZeroClaw doesn't simplify their architecture. It ignores it and writes the lo
 |                   | SubZeroClaw  | ZeroClaw     | OpenClaw     |
 |-------------------|--------------|--------------|--------------|
 | Language          | C            | Rust         | TypeScript   |
-| Source            | ~380 lines   | ~15,000      | ~430,000     |
-| Binary            | 54 KB        | 3.4 MB       | 80+ MB       |
-| RAM (runtime)     | ~2 MB        | < 5 MB       | 80-120 MB    |
-| Compiles on Pi    | 0.5s         | OOM          | slow         |
-| Dependencies      | curl, cJSON  | ~100 crates  | ~800 npm     |
+| Source            | ~550 lines        | ~15,000      | ~430,000     |
+| Binary            | 55 KB             | 3.4 MB       | 80+ MB       |
+| RAM (runtime)     | ~2 MB             | < 5 MB       | 80-120 MB    |
+| Compiles on Pi    | 0.5s              | OOM          | slow         |
+| Dependencies      | curl, unhardcoded | ~100 crates  | ~800 npm     |
 
 ## Tool
 
@@ -122,7 +122,7 @@ The skills included in this repo (`skills/`) are just examples to show the forma
 ## Build
 
 ```bash
-make            # builds subzeroclaw (54KB)
+make            # builds subzeroclaw (55KB)
 make test       # runs the test suite
 make install    # copies to ~/.local/bin/
 ```
@@ -237,7 +237,7 @@ Every session gets a random hex ID. All input, output, tool calls, and results a
 
 ```
 src/
-├── subzeroclaw.c   ~380 lines  The entire runtime
+├── subzeroclaw.c   ~550 lines  The entire runtime
 ├── test.c                      the test suite
 ├── cJSON.c                     Vendored JSON parser
 └── cJSON.h
@@ -253,7 +253,7 @@ Every layer of "framework" between the model and the shell is complexity that ad
 
 OpenClaw solved the agentic loop with 430,000 lines of TypeScript. ZeroClaw re-solved it with 15,000 lines of Rust. Both are good — but both carry the weight of problems that only exist at platform scale: multi-tenancy, channel routing, identity portability, plugin registries.
 
-SubZeroClaw asks: what if the problem is just "one agent, one skill, one device"? Then the answer is ~380 readable lines of C.
+SubZeroClaw asks: what if the problem is just "one agent, one skill, one device"? Then the answer is ~550 readable lines of C.
 
 ## License
 

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,11 @@
+<svg width="180" height="180" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="SubZeroClaw">
+  <defs>
+    <radialGradient id="sun" cx="38%" cy="33%" r="78%">
+      <stop offset="0%" stop-color="#C9633F"/>
+      <stop offset="60%" stop-color="#A84E36"/>
+      <stop offset="100%" stop-color="#7E3A22"/>
+    </radialGradient>
+  </defs>
+  <circle cx="20" cy="20" r="10" fill="url(#sun)"/>
+  <circle cx="12.5" cy="27.5" r="4.2" fill="#26241F"/>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -4,19 +4,19 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>SubZeroClaw — an agent small enough to run anywhere</title>
-<meta name="description" content="SubZeroClaw is a minimal agent runtime in C — ~380 lines, a 54KB binary, ~2MB RAM. No framework, just the loop. Small enough to run anywhere: edge devices, local automation, and large-scale swarms." />
+<meta name="description" content="SubZeroClaw is a minimal agent runtime in C — ~550 lines, a 55KB binary, ~2MB RAM. No framework, just the loop. Small enough to run anywhere: edge devices, local automation, and large-scale swarms." />
 <link rel="canonical" href="https://subzeroclaw.com/" />
 <meta name="theme-color" content="#E9E0D2" />
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="SubZeroClaw" />
 <meta property="og:title" content="SubZeroClaw — an agent small enough to run anywhere" />
-<meta property="og:description" content="A minimal agent runtime in C. ~380 lines · 54KB · ~2MB RAM · 2 deps. No framework, just the loop." />
+<meta property="og:description" content="A minimal agent runtime in C. ~550 lines · 55KB · ~2MB RAM · 2 deps. No framework, just the loop." />
 <meta property="og:url" content="https://subzeroclaw.com/" />
 <meta property="og:image" content="https://subzeroclaw.com/og.png" />
 <meta property="og:image:type" content="image/png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="SubZeroClaw — an agent small enough to run anywhere. 380 lines of C, 54 KB, ~2 MB RAM, 2 deps." />
+<meta property="og:image:alt" content="SubZeroClaw — an agent small enough to run anywhere. 550 lines of C, 55 KB, ~2 MB RAM, 2 deps." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="SubZeroClaw — an agent small enough to run anywhere" />
 <meta name="twitter:description" content="A minimal agent runtime in C. No framework, just the loop." />
@@ -31,7 +31,7 @@
   "@type": "SoftwareSourceCode",
   "name": "SubZeroClaw",
   "alternateName": "SZC",
-  "description": "A minimal agentic runtime in C — ~380 lines, a 54KB binary, ~2MB RAM. One skill file plus an LLM plus a shell loop, with no framework. Small enough to run anywhere: edge devices, Raspberry Pi, local automation, and large-scale agent swarms.",
+  "description": "A minimal agentic runtime in C — ~550 lines, a 55KB binary, ~2MB RAM. One skill file plus an LLM plus a shell loop, with no framework. Small enough to run anywhere: edge devices, Raspberry Pi, local automation, and large-scale agent swarms.",
   "url": "https://subzeroclaw.com/",
   "image": "https://subzeroclaw.com/og.png",
   "codeRepository": "https://github.com/genlayerlabs/subzeroclaw",
@@ -138,7 +138,7 @@ footer{border-top:1px solid var(--line)}
       <span class="cmd">git clone github.com/genlayerlabs/subzeroclaw</span>
       <span class="lbl" aria-live="polite">copy</span>
     </button>
-    <p class="stats">380 lines of C · 54 KB · ~2 MB RAM · 2 deps</p>
+    <p class="stats">550 lines of C · 55 KB · ~2 MB RAM · 2 deps</p>
   </div>
 
   <div class="orbit-stage">

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,15 +1,15 @@
 # SubZeroClaw
 
-> A minimal agentic runtime written in C: ~380 lines of source, a 54KB binary, ~2MB RAM at runtime. One skill file + one LLM + one shell loop. No framework, no plugins, no adapters. Small enough to run anywhere — edge devices, Raspberry Pi, local automation, and large-scale agent swarms.
+> A minimal agentic runtime written in C: ~550 lines of source, a 55KB binary, ~2MB RAM at runtime. One skill file + one LLM + one shell loop. No framework, no plugins, no adapters. Small enough to run anywhere — edge devices, Raspberry Pi, local automation, and large-scale agent swarms.
 
-SubZeroClaw connects an LLM to a shell and loops: it reads a skill (a plain markdown file), calls the model, runs the one tool the model asks for (the shell), and repeats until the task is done. Because the only tool is the shell, any CLI you already have installed (git, curl, ffmpeg, jq, rsync, ...) is immediately available to the agent — there are no integrations to build. When the message history grows past a limit, it compacts old messages into a summary and continues.
+SubZeroClaw connects an LLM to a shell and loops: it reads a skill (a plain markdown file), calls the model, runs the one tool the model asks for (the shell), and repeats until the task is done. Because the only tool is the shell, any CLI you already have installed (git, curl, ffmpeg, jq, rsync, ...) is immediately available to the agent — there are no integrations to build. When context grows, the runtime does not summarize in-process: the unhardcoded router signals pressure (an `x_router.compact` flag) and the old turns are sealed asynchronously in the background (append-only), so the loop never pauses.
 
 ## Facts
 
-- Language: C (~380 lines of runtime in a single file)
-- Binary size: 54 KB
+- Language: C (~550 lines of runtime in a single file)
+- Binary size: 55 KB
 - RAM at runtime: ~2 MB
-- Dependencies: curl (called via the shell), cJSON (vendored fallback if libcjson is absent)
+- Dependencies: a shell with curl, and unhardcoded (the router substrate — model selection, prompt-cache affinity, context compaction; MIT). cJSON is vendored in-repo, not a dependency.
 - License: MIT
 - Compiles on a Raspberry Pi in ~0.5s
 - Provider: any OpenAI-compatible endpoint (defaults to OpenRouter)


### PR DESCRIPTION
## Problem

The public self-description had drifted from the runtime as it grew (v0.1 → #20). README, the landing page, and `llms.txt` advertised **~380 lines / 54KB**; measured today at #20 the runtime is **553 lines of code** (624 total) and a **56KB (54.7 KiB)** binary. RAM (~2 MB, measured 2068 kB) was correct.

No runtime change — the C is untouched. This only reconciles the docs with what the artifact actually is (verum).

## Changes

- **Lines** ~380 → ~550 (the code-line count the headline means) — README headline, comparison table, source tree, philosophy; site meta/JSON-LD/stats; `llms.txt`.
- **Binary** 54KB → 55KB (54.7 KiB; `make` does not strip).
- **Dependencies** `curl, cJSON` → `curl, unhardcoded`. cJSON is vendored in-repo (`src/cJSON.c`), so it is not a dependency. The agent's two real dependencies are a shell (with `curl`) and the **unhardcoded** router substrate (MIT) — per the runtime's substrate stance (#18).
- **README logo**: swap the old ice "SZ" wordmark (`szc-logo.png`) for the site's current mark (`logo.svg` — clay sun + black hole), so the README matches the landing-page identity.
- **`llms.txt` compaction note**: it still described in-process summarization; rewritten as the async router seal (#18) the README already documents.

## Verification

`make HAVE_SYSTEM_CJSON=no test` → **31 passed, 0 failed**. No behavior touched.

## Residual / follow-ups (not in this PR)

- `site/og.png` is a rasterized social card still showing "380 lines / 54 KB" — needs regeneration (no image toolchain to hand).
- `szc-logo.png` is now unreferenced; can be removed in a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project docs and website copy to reflect the latest runtime size and binary footprint.
  * Refreshed architecture and comparison details, including dependency wording and updated source-size figures.
  * Aligned the public AI-facing project description with the new size and memory stats.
* **Style**
  * Updated visible marketing and metadata text across the site to match the latest reported build metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->