### PR TITLE
docs: ship Claude Code skills (use + contribute) + reconcile stale docs

### DIFF
--- a/.claude/skills/subzeroclaw-contribute/SKILL.md
+++ b/.claude/skills/subzeroclaw-contribute/SKILL.md
@@ -38,7 +38,7 @@ The loop, top to bottom:
 
 | Function | Role |
 |---|---|
-| `config_parse_line` / `config_load` | parse the config keys; env overrides; **scrub `SUBZEROCLAW_*` from the environment** so the model's shell never sees the key. |
+| `config_parse_line` / `config_load` | parse the config keys; env overrides; **scrub the four provider secrets** (`SUBZEROCLAW_API_KEY`/`_ENDPOINT`/`_REQUEST_EXTRA`/`_COMPACT_EXTRA`) from the environment (wipe-in-place + `unsetenv`) so the model's shell never sees the key. `SUBZEROCLAW_SKILLS` is preserved on purpose. |
 | `main` | read config + skills, build the system prompt, seed the message array, drive the loop. |
 | `agent_run` | the turn loop: POST to `endpoint`, parse, dispatch tools, until a stop or `max_turns`. |
 | `parse_response` | pull assistant text / tool calls / errors out of the completion JSON. |

--- a/.claude/skills/subzeroclaw-contribute/SKILL.md
+++ b/.claude/skills/subzeroclaw-contribute/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: subzeroclaw-contribute
+description: >-
+  Develop SubZeroClaw — the single-file ~550-line C agentic runtime. Load this
+  before changing src/subzeroclaw.c or src/test.c: it carries the anti-framework
+  thesis (the goal is NOT to grow), the code map (the loop, config, the shell
+  tool, async compaction), what will and won't be merged, and the build/test
+  loop. To merely run or configure SubZeroClaw, use subzeroclaw-use.
+---
+
+# Contributing to SubZeroClaw
+
+SubZeroClaw is an **anti-framework**: the goal is not to grow but to stay minimal,
+readable and correct. The whole runtime is one file, `src/subzeroclaw.c`
+(~550 lines). Before you add anything, read `CONTRIBUTING.md` — a PR that *adds*
+surface has to clear a high bar, and several categories are refused outright.
+
+## The two contributions that are welcome
+
+1. **Reduce complexity** — same behaviour with less code, fewer moving parts, or
+   clearer logic: remove a function that doesn't earn its place, flatten a control
+   path, drop a dependency or an allocation, replace a hand-rolled pattern with
+   libc. A PR that removes lines while keeping tests green is probably good.
+2. **Prove a runtime limitation** — a task where "skill + shell + LLM loop" genuinely
+   breaks down *in the runtime, not the skill*. The honest test: could a better
+   `.md` skill fix it? If yes, it's a skill problem, not a SubZeroClaw one. If the
+   limitation is structural (e.g. binary tool output can't round-trip through the
+   JSON string protocol), that's worth discussing. Open an issue with the task, the
+   skill you wrote, what happened, and why no skill can work around it.
+
+**Won't be merged:** new tools (the shell is the only tool — the model runs `git`,
+`tee`, `curl` itself); plugin systems, hooks, event buses, middleware (multi-user
+platform problems SubZeroClaw doesn't have); backward-compatibility shims.
+
+## Code map (`src/subzeroclaw.c`)
+
+The loop, top to bottom:
+
+| Function | Role |
+|---|---|
+| `config_parse_line` / `config_load` | parse the config keys; env overrides; **scrub `SUBZEROCLAW_*` from the environment** so the model's shell never sees the key. |
+| `main` | read config + skills, build the system prompt, seed the message array, drive the loop. |
+| `agent_run` | the turn loop: POST to `endpoint`, parse, dispatch tools, until a stop or `max_turns`. |
+| `parse_response` | pull assistant text / tool calls / errors out of the completion JSON. |
+| `process_tool_calls` | the **one tool**: run each shell command via `popen()` (stderr merged), append results as turns. |
+| `round_has_command` | guard: did this round actually request a shell command? |
+| `compact_fire` / `compact_splice` / `compact_url` | async context sealing: on the router's `x_router.compact` signal, fire `/v1/compact` in the background and splice the sealed block in ahead of intervening turns — no turn is ever blocked. |
+| `log_write`, `write_temp`, `mkdirp` | session logging + scratch files. |
+
+`cJSON` is vendored (`src/cJSON.c/.h`) and used automatically when system
+`libcjson` is absent (the Makefile detects it via `pkg-config`).
+
+## Build & test
+
+```bash
+make            # single-file build → subzeroclaw (needs gcc; -lm or -lcjson)
+make test       # builds test_subzeroclaw and runs the suite → "31 passed, 0 failed"
+make install    # → ~/.local/bin/
+make clean
+```
+
+`src/test.c` `#include`s `src/subzeroclaw.c` directly and defines `SZC_TEST` to
+exclude `main`, so tests link against the real functions. **All 31 tests must
+pass**, and if you change `subzeroclaw.c` you must update `test.c` to match — the
+suite covers the shell tool, turn framing, request building + `request_extra`
+merge, response/error parsing, the compact flag + splice, tool dispatch, the
+system prompt, skill loading, and config (including the env scrub).
+
+## The bar, restated
+
+Every line justifies its existence. The code that remains is the code that can't
+be removed. If your change grows the file, the burden is on you to show the
+runtime — not a skill — needed it. See `CONTRIBUTING.md` for the full policy.

--- a/.claude/skills/subzeroclaw-use/SKILL.md
+++ b/.claude/skills/subzeroclaw-use/SKILL.md
@@ -50,7 +50,7 @@ is the canonical template.
 
 | Key | Meaning |
 |---|---|
-| `api_key` | OpenRouter (or unhardcoded router) key. **Required.** |
+| `api_key` | The unhardcoded router **consumer key** (`llmr_…`) — SubZeroClaw is designed to run on the router. A bare OpenRouter/provider key also works but is a degraded loop. **Required.** |
 | `request_extra` | JSON merged into every request body. **Carries the model** (`{"model":"..."}`) — there is no dedicated `model` key. Against a router it also carries the routing `policy_ir`. Override wins on key collision. |
 | `compact_extra` | JSON enabling async compaction: `keep_recent` + a cheap summariser `policy_ir`. Unset → no compaction. |
 | `endpoint` | default OpenRouter; point at an unhardcoded router for routing/cache/compaction. |
@@ -83,10 +83,13 @@ Pointed at a bare provider the HTTP call still fires, but it's a **degraded** lo
 SubZeroClaw doesn't supervise itself — bring your init system. A systemd unit with
 `Restart=on-failure` and an `EnvironmentFile` (root-owned, `chmod 600`) holding
 `SUBZEROCLAW_API_KEY` gets you restart + credential isolation. The runtime
-**scrubs `SUBZEROCLAW_*` from its own environment** right after `config_load`, so
-the shell it hands the model never inherits the key (`cat /proc/self/environ`
-comes up empty). The supervisor owns the secret; the shell stays unguarded by
-design — the scrub only keeps the runtime's *own* key out of it.
+**scrubs the four provider secrets** (`SUBZEROCLAW_API_KEY`, `_ENDPOINT`,
+`_REQUEST_EXTRA`, `_COMPACT_EXTRA`) from its own environment right after
+`config_load` — wiping the value in place, then `unsetenv` — so the shell it hands
+the model never inherits the key (`cat /proc/self/environ` comes up empty).
+Non-secret vars like `SUBZEROCLAW_SKILLS` are deliberately kept (the genswarms
+wrapper sets it). The supervisor owns the secret; the shell stays unguarded by
+design — the scrub only keeps the runtime's *own* secrets out of it.
 
 ## Gotchas
 

--- a/.claude/skills/subzeroclaw-use/SKILL.md
+++ b/.claude/skills/subzeroclaw-use/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: subzeroclaw-use
+description: >-
+  Run and operate SubZeroClaw — the ~550-line C agentic daemon (skill.md + LLM +
+  shell + loop). Load this to build it, configure it (~/.subzeroclaw/config),
+  write an agent skill, run a task, wire it to an unhardcoded router for
+  routing/cache/compaction, or run it as a systemd service with credential
+  isolation. WARNING: it executes arbitrary shell with no sandbox. To develop
+  the runtime itself, use subzeroclaw-contribute.
+---
+
+# Using SubZeroClaw
+
+**Read the warning first.** SubZeroClaw runs whatever the model emits through
+`popen()` — no confirmation, no sandbox, `rm -rf /` included. There is nothing
+between the model's output and your system. Run it only where you accept that,
+ideally as an unprivileged service user (see *As a service*).
+
+The whole runtime is: **read a skill (markdown) → call an LLM → run shell tools →
+loop until done**. One tool: `shell`. The "adapter" for git/curl/email/ffmpeg is
+that they're one `popen()` away — install the CLI, the model uses it.
+
+> **Two senses of "skill" — don't conflate them.** A *SubZeroClaw skill* is a
+> plain `.md` file in `~/.subzeroclaw/skills/` that becomes the agent's system
+> prompt (what the agent knows). *This* file is a Claude Code skill (how to
+> operate the tool). When the docs below say "write a skill", they mean the
+> former.
+
+## Build & run
+
+```bash
+git clone https://github.com/genlayerlabs/subzeroclaw && cd subzeroclaw
+make                                   # ~0.5s → the 55KB binary (needs gcc; curl at runtime)
+mkdir -p ~/.subzeroclaw/skills
+# ...write ~/.subzeroclaw/config (below) and a skill .md...
+./subzeroclaw "check disk usage and clean tmp if over 80%"   # one-shot
+./subzeroclaw                                                 # interactive
+make install                           # → ~/.local/bin/
+```
+
+An agent skill is just prose the LLM reads — no format, no registry, no trigger
+matching. Drop a `.md` in `~/.subzeroclaw/skills/` and it joins the system
+prompt. The repo's `skills/*.md` are format *examples* tied to one setup; write
+your own.
+
+## Configuration (`~/.subzeroclaw/config`)
+
+These are the only keys the runtime parses (`config_parse_line`); `config.example`
+is the canonical template.
+
+| Key | Meaning |
+|---|---|
+| `api_key` | OpenRouter (or unhardcoded router) key. **Required.** |
+| `request_extra` | JSON merged into every request body. **Carries the model** (`{"model":"..."}`) — there is no dedicated `model` key. Against a router it also carries the routing `policy_ir`. Override wins on key collision. |
+| `compact_extra` | JSON enabling async compaction: `keep_recent` + a cheap summariser `policy_ir`. Unset → no compaction. |
+| `endpoint` | default OpenRouter; point at an unhardcoded router for routing/cache/compaction. |
+| `skills_dir`, `log_dir` | defaults under `~/.subzeroclaw/`. |
+| `max_turns` | tool-call loops per input (default 200). |
+
+Env vars `SUBZEROCLAW_API_KEY`, `SUBZEROCLAW_ENDPOINT`, `SUBZEROCLAW_REQUEST_EXTRA`,
+`SUBZEROCLAW_COMPACT_EXTRA` override the file.
+
+## The unhardcoded substrate (routing + compaction)
+
+Routing with prompt-cache affinity and context compaction are *not* part of
+"skill + LLM + shell + loop" — they live in the substrate. Point `endpoint` at an
+[unhardcoded](https://github.com/genlayerlabs/unhardcoded) router and express them
+as JSON:
+- **Routing:** `request_extra = {"model":"policy:auto","policy_ir":[ … ]}`. The
+  runtime sends a per-run `session` id so the router keeps the conversation on its
+  cache-hot peer. (Author the `policy_ir` with the **`unhardcoded-use`** skill.)
+- **Compaction:** on an `x_router.compact` signal, the runtime fires an
+  append-only seal at the router's `/v1/compact` **in the background** and keeps
+  taking turns, splicing the sealed block in ahead of the turns that arrived
+  meanwhile — no pause, the cache prefix is never rewritten. `compact_extra`
+  carries `keep_recent` + the summariser policy.
+
+Pointed at a bare provider the HTTP call still fires, but it's a **degraded** loop
+(no routing, cache, or compaction) — not a supported standalone mode.
+
+## As a service (and credential isolation)
+
+SubZeroClaw doesn't supervise itself — bring your init system. A systemd unit with
+`Restart=on-failure` and an `EnvironmentFile` (root-owned, `chmod 600`) holding
+`SUBZEROCLAW_API_KEY` gets you restart + credential isolation. The runtime
+**scrubs `SUBZEROCLAW_*` from its own environment** right after `config_load`, so
+the shell it hands the model never inherits the key (`cat /proc/self/environ`
+comes up empty). The supervisor owns the secret; the shell stays unguarded by
+design — the scrub only keeps the runtime's *own* key out of it.
+
+## Gotchas
+
+- **A top-level `model =` line in the config is ignored** — the runtime never
+  parses it. The model rides in `request_extra`. (This is the most common
+  misconfiguration.)
+- **Use a tool-calling model.** If the model can't call tools it will loop without
+  progress. Set it in `request_extra`.
+- **`curl` is required at runtime** (API calls shell out to it); `gcc` only to build.
+- **Compaction is opt-in:** unset `compact_extra` → context grows until the
+  provider refuses it.
+
+## Where to read more
+
+- `README.md` — the full config reference, session logging, troubleshooting table.
+- `config.example` — the canonical config template.
+- The **`unhardcoded-use`** / `sigma-policy-author` skills — author the routing and
+  summariser `policy_ir` this runtime sends.

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # Copy this file to .env and fill in your real values
 # Then: source .env
+#
+# SubZeroClaw is designed to run on an unhardcoded router: a consumer key (llmr_)
+# and the router endpoint. Env vars are used raw (no quote-stripping), so keep the
+# request_extra JSON in single quotes. There is no SUBZEROCLAW_MODEL — the model
+# rides in request_extra.
 
-export SUBZEROCLAW_API_KEY="sk-or-your-openrouter-key-here"
-export SUBZEROCLAW_MODEL="minimax/minimax-m2.5"
-# export SUBZEROCLAW_ENDPOINT="https://openrouter.ai/api/v1/chat/completions"
+export SUBZEROCLAW_API_KEY="llmr_your-unhardcoded-consumer-key"
+export SUBZEROCLAW_ENDPOINT="https://YOUR-UNHARDCODED-ROUTER/v1/chat/completions"
+# "policy:auto" lets the router pick; author the policy_ir with the unhardcoded-use
+# skill. Direct-provider fallback (degraded): '{"model":"minimax/minimax-m2.5"}'.
+export SUBZEROCLAW_REQUEST_EXTRA='{"model":"policy:auto","policy_ir":["policy","..."]}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Examples of bad PRs:
 - Compressing readable code into fewer lines at the expense of clarity
 - Adding configuration for something that works fine hardcoded
 
-The code is currently ~380 lines. Every line should justify its existence. If yours removes lines while keeping tests green, it's probably good.
+The runtime is currently ~550 lines of C (`src/subzeroclaw.c`). Every line should justify its existence. If yours removes lines while keeping tests green, it's probably good.
 
 ## 2. Prove a limitation of the anti-framework
 
@@ -49,4 +49,4 @@ This forces an honest conversation: does SubZeroClaw actually need to grow, or d
 make test
 ```
 
-All 16 tests must pass. If you change `subzeroclaw.c`, update `test.c` to match.
+All 31 tests must pass. If you change `subzeroclaw.c`, update `test.c` to match.

--- a/README.md
+++ b/README.md
@@ -35,17 +35,25 @@ make                          # builds the 55KB binary in ~0.5s
 
 mkdir -p ~/.subzeroclaw/skills
 cat > ~/.subzeroclaw/config << 'EOF'
-api_key = "sk-or-your-openrouter-key"
-# The model is no longer a dedicated key — it rides in request_extra (the generic
-# body-override channel). Direct provider: set the model. Against an unhardcoded
-# router: send a policy instead — see "Routing & compaction via unhardcoded".
-request_extra = {"model": "minimax/minimax-m2.5"}
+# SubZeroClaw is designed to run on an unhardcoded router: a consumer key (llmr_,
+# minted in the router dashboard) and the router endpoint. The model is not a
+# dedicated key — it rides in request_extra as BARE JSON; "policy:auto" lets the
+# router pick (author the policy_ir with the unhardcoded-use skill).
+api_key  = "llmr_your-unhardcoded-consumer-key"
+endpoint = "https://YOUR-UNHARDCODED-ROUTER/v1/chat/completions"
+request_extra = {"model":"policy:auto","policy_ir":["policy", "..."]}
 EOF
 
 ./subzeroclaw "check disk usage and clean tmp if over 80%"
 ```
 
-Clone, build, drop in an [OpenRouter](https://openrouter.ai) key, run. No daemon to register, no service to start. You need `gcc` to build and `curl` at runtime — everything else is in the box.
+Clone, build, point it at your [unhardcoded](https://github.com/genlayerlabs/unhardcoded) router, run. No daemon to register, no service to start. You need `gcc` to build and `curl` at runtime — everything else is in the box.
+
+> **Degraded standalone mode.** You can instead point `endpoint` at a bare
+> provider with its own key (e.g. an [OpenRouter](https://openrouter.ai) `sk-or-…`
+> key and a direct `request_extra = {"model": "minimax/minimax-m2.5"}`). The loop
+> still runs, but with no routing, prompt-cache affinity, or compaction — context
+> grows until the provider refuses it. Not a supported standalone mode.
 
 ## Routing & compaction via unhardcoded
 
@@ -134,12 +142,15 @@ Requires `libcjson-dev` or uses vendored cJSON automatically.
 ```bash
 mkdir -p ~/.subzeroclaw/skills
 
-cat > ~/.subzeroclaw/config << EOF
-api_key = "sk-or-your-openrouter-key"
-# The model is no longer a dedicated key — it rides in request_extra (the generic
-# body-override channel). Direct provider: set the model. Against an unhardcoded
-# router: send a policy instead — see "Routing & compaction via unhardcoded".
-request_extra = {"model": "minimax/minimax-m2.5"}
+cat > ~/.subzeroclaw/config << 'EOF'
+# Against an unhardcoded router (the supported mode): consumer key + endpoint.
+api_key  = "llmr_your-unhardcoded-consumer-key"
+endpoint = "https://YOUR-UNHARDCODED-ROUTER/v1/chat/completions"
+# The model rides in request_extra as BARE JSON (no surrounding quotes, no
+# backslash-escaping — the parser strips one pair of quotes but does not unescape).
+# "policy:auto" lets the router pick; author the policy_ir with the unhardcoded-use
+# skill. Direct-provider fallback (degraded): {"model": "minimax/minimax-m2.5"}.
+request_extra = {"model":"policy:auto","policy_ir":["policy", "..."]}
 EOF
 ```
 
@@ -218,7 +229,7 @@ Every session gets a random hex ID. All input, output, tool calls, and results a
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `api_key` | (required) | OpenRouter (or unhardcoded) API key |
+| `api_key` | (required) | The unhardcoded router consumer key (`llmr_…`); an OpenRouter/provider key works in the degraded standalone mode |
 | `request_extra` | (none) | the loop JSON merged into every request body — carries the `model`, and against an unhardcoded router the routing `policy_ir` |
 | `compact_extra` | (none) | the compaction JSON — `keep_recent` + the cheap summariser `policy_ir`; unset disables compaction |
 | `endpoint` | `https://openrouter.ai/api/v1/chat/completions` | API endpoint (point it at an unhardcoded router for routing/cache/compaction) |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ api_key = "sk-or-your-openrouter-key"
 # The model is no longer a dedicated key — it rides in request_extra (the generic
 # body-override channel). Direct provider: set the model. Against an unhardcoded
 # router: send a policy instead — see "Routing & compaction via unhardcoded".
-request_extra = "{\"model\": \"minimax/minimax-m2.5\"}"
+request_extra = {"model": "minimax/minimax-m2.5"}
 EOF
 
 ./subzeroclaw "check disk usage and clean tmp if over 80%"
@@ -139,7 +139,7 @@ api_key = "sk-or-your-openrouter-key"
 # The model is no longer a dedicated key — it rides in request_extra (the generic
 # body-override channel). Direct provider: set the model. Against an unhardcoded
 # router: send a policy instead — see "Routing & compaction via unhardcoded".
-request_extra = "{\"model\": \"minimax/minimax-m2.5\"}"
+request_extra = {"model": "minimax/minimax-m2.5"}
 EOF
 ```
 
@@ -193,8 +193,10 @@ EnvironmentFile=/etc/subzeroclaw.env   # root-owned, chmod 600: SUBZEROCLAW_API_
 This also gets you credential isolation for free, and it is the recommended way
 to hold the key: run the agent as an unprivileged `User=`, and deliver the key
 through the environment from a root-owned `EnvironmentFile` the agent's user
-cannot read. SubZeroClaw scrubs `SUBZEROCLAW_*` from its own environment right
-after reading config (see `config_load`), so the shell it hands the model never
+cannot read. SubZeroClaw scrubs the provider secrets (`SUBZEROCLAW_API_KEY`,
+`_ENDPOINT`, `_REQUEST_EXTRA`, `_COMPACT_EXTRA`) from its own environment right
+after reading config (see `config_load`; non-secret vars like `SUBZEROCLAW_SKILLS`
+are kept), so the shell it hands the model never
 inherits the key — `echo $SUBZEROCLAW_API_KEY` and `cat /proc/self/environ` come
 up empty. The supervisor owns the secret; the agent only ever holds a copy in
 memory. (None of this constrains what the shell can *do* — that is still

--- a/config.example
+++ b/config.example
@@ -1,9 +1,23 @@
 # SubZeroClaw configuration
-# Copy to ~/.subzeroclaw/config and edit
+# Copy to ~/.subzeroclaw/config and edit.
+# These are exactly the keys the runtime parses (see config_parse_line in
+# src/subzeroclaw.c); anything else in this file is ignored.
 
 api_key = "sk-or-your-openrouter-key-here"
-model = "minimax/minimax-m2.5"
-# endpoint = "https://openrouter.ai/api/v1/chat/completions"
+
+# The model is NOT a dedicated key — it rides in request_extra, the JSON merged
+# into every request body. Direct provider: set {"model": "..."}. Against an
+# unhardcoded router: send a routing policy instead, e.g.
+#   {"model":"policy:auto","policy_ir":[ ... ]}  (see the README).
+# On a key collision, this override wins.
+request_extra = "{\"model\": \"minimax/minimax-m2.5\"}"
+
+# compact_extra enables async context sealing against an unhardcoded router's
+# /v1/compact: keep_recent (turns kept verbatim) + a cheap summariser policy.
+# Unset => no compaction (context grows until the provider refuses it).
+# compact_extra = "{\"keep_recent\": 8, \"policy_ir\": [ ... ]}"
+
+# endpoint   = "https://openrouter.ai/api/v1/chat/completions"
 # skills_dir = "~/.subzeroclaw/skills"
-# max_turns = 50
-# request_extra = '{"temperature": 0.2}'  # optional JSON object merged into every request body
+# log_dir    = "~/.subzeroclaw/logs"
+# max_turns  = 200

--- a/config.example
+++ b/config.example
@@ -3,21 +3,30 @@
 # These are exactly the keys the runtime parses (see config_parse_line in
 # src/subzeroclaw.c); anything else in this file is ignored.
 
-api_key = "sk-or-your-openrouter-key-here"
+# SubZeroClaw is designed to run on an unhardcoded router (routing with
+# prompt-cache affinity + async compaction). So the key is an unhardcoded
+# *consumer* key (llmr_…, minted in the router dashboard → Consumers), and
+# `endpoint` points at the router. A bare OpenRouter/provider key still works but
+# is a DEGRADED loop — no routing, no cache, no compaction (see the README).
+api_key  = "llmr_your-unhardcoded-consumer-key"
+endpoint = "https://YOUR-UNHARDCODED-ROUTER/v1/chat/completions"
 
 # The model is NOT a dedicated key — it rides in request_extra, the JSON merged
-# into every request body. Direct provider: set {"model": "..."}. Against an
-# unhardcoded router: send a routing policy instead, e.g.
-#   {"model":"policy:auto","policy_ir":[ ... ]}  (see the README).
-# On a key collision, this override wins.
-request_extra = "{\"model\": \"minimax/minimax-m2.5\"}"
+# into every request body. Give it as BARE JSON: no surrounding quotes and no
+# backslash-escaping. The parser strips at most one pair of outer quotes and does
+# NOT unescape, so a quoted "{\"model\":...}" reaches the JSON parser with literal
+# backslashes and is silently dropped.
+#
+# Against the router, send a routing policy (author it with the unhardcoded-use
+# skill); "policy:auto" tells the router to pick:
+request_extra = {"model":"policy:auto","policy_ir":["policy", "..."]}
+# Direct provider instead (degraded, no router): {"model": "minimax/minimax-m2.5"}
 
-# compact_extra enables async context sealing against an unhardcoded router's
-# /v1/compact: keep_recent (turns kept verbatim) + a cheap summariser policy.
-# Unset => no compaction (context grows until the provider refuses it).
-# compact_extra = "{\"keep_recent\": 8, \"policy_ir\": [ ... ]}"
+# compact_extra enables async context sealing at the router's /v1/compact:
+# keep_recent (turns kept verbatim) + a cheap summariser policy. Bare JSON, same
+# rule as request_extra. Unset => no compaction.
+# compact_extra = {"keep_recent": 8, "policy_ir": ["policy", "..."]}
 
-# endpoint   = "https://openrouter.ai/api/v1/chat/completions"
 # skills_dir = "~/.subzeroclaw/skills"
 # log_dir    = "~/.subzeroclaw/logs"
 # max_turns  = 200


### PR DESCRIPTION
## What

Ship two repo-shipped **Claude Code skills** so an agent can operate or develop SubZeroClaw by reading a skill, plus reconcile a few docs against the artifact (each verified by reading the code or running the suite — not by re-reading prose).

### Skills (`.claude/skills/`)
- **`subzeroclaw-use`** — build, configure (`~/.subzeroclaw/config`), write an agent skill, run a task; wire it to an unhardcoded router for routing/cache/compaction; run it as a systemd service with credential isolation (the `SUBZEROCLAW_*` env scrub). Leads with the unguarded-shell warning and disambiguates a *SubZeroClaw agent skill* (`~/.subzeroclaw/skills/*.md`) from a Claude Code skill.
- **`subzeroclaw-contribute`** — the anti-framework thesis (the goal is not to grow), the single-file code map (`agent_run` loop, the shell tool, the async compaction splice, the env scrub), what will/won't be merged, and the build/test loop.

Each skill orients and points into `README.md` / `CONTRIBUTING.md` rather than restating them.

### Doc reconciliation (verified against the artifact)
- **`config.example`** advertised a dedicated `model = "..."` key — but `config_parse_line` (`src/subzeroclaw.c`) never parses one, so the runtime **silently ignores it**. The model rides in `request_extra` (as the README already says). Rewrote the template to exactly the keys the code reads and documented `compact_extra`.
- **`CONTRIBUTING.md`**: `~380 lines` → `~550` — `src/subzeroclaw.c` is 553 SLOC (`grep -cvE '^\s*(//|/\*|\*|$)'`), matching the README's own figure. `All 16 tests` → `31` — `make test` reports `31 passed, 0 failed`.

## Verification
- `make test` → `31 passed, 0 failed` (before and after; no code touched).
- Build artifacts stay gitignored; the change is skills + `config.example` + two numbers in `CONTRIBUTING.md`.
- The README's hero `~550 lines` / `55KB` framing is accurate (SLOC 553) and left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new contribution guidance for the SubZeroClaw “anti-framework” approach, including allowed vs. non-merge contribution categories.
  * Added a usage guide for operating the SubZeroClaw daemon and authoring skills.
  * Updated README and configuration docs/examples to emphasize unhardcoded-router setup, including `request_extra` model handling and optional async compaction details.
* **Chores**
  * Refreshed `CONTRIBUTING.md`, `config.example`, and `.env.example` to match current config parsing rules and updated test expectations (31 tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->