### PR TITLE
feat: compact context synchronously with contract v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y libcjson-dev
+      - name: System cJSON
+        run: make && make test
+      - name: Vendored cJSON
+        run: make clean && make HAVE_SYSTEM_CJSON=no && make HAVE_SYSTEM_CJSON=no test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Examples of bad PRs:
 - Compressing readable code into fewer lines at the expense of clarity
 - Adding configuration for something that works fine hardcoded
 
-The runtime is currently ~550 lines of C (`src/subzeroclaw.c`). Every line should justify its existence. If yours removes lines while keeping tests green, it's probably good.
+The runtime is one small C file (`src/subzeroclaw.c`). Every line should justify its existence; this guide is not a growth ratchet. A smaller diff is better only when it preserves transport secrecy, all-call tool preflight and result pairing, fail-closed compaction, and the log schema. Green tests are necessary, not proof by themselves.
 
 ## 2. Prove a limitation of the anti-framework
 
@@ -49,4 +49,4 @@ This forces an honest conversation: does SubZeroClaw actually need to grow, or d
 make test
 ```
 
-All 31 tests must pass. If you change `subzeroclaw.c`, update `test.c` to match.
+All tests must pass. If you change `subzeroclaw.c`, update `test.c` to match.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ TARGET  = subzeroclaw
 # Use system libcjson if available, otherwise use vendored copy
 HAVE_SYSTEM_CJSON := $(shell pkg-config --exists libcjson 2>/dev/null && echo yes)
 ifeq ($(HAVE_SYSTEM_CJSON),yes)
-  LDFLAGS = -lcjson
+  CFLAGS  += $(shell pkg-config --cflags libcjson)
+  LDFLAGS = $(shell pkg-config --libs libcjson)
 else
   CFLAGS  += -Isrc
   VENDOR  = src/cJSON.c

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **WARNING: This software executes arbitrary shell commands with no safety checks, no confirmation prompts, no sandboxing, and no guardrails. The LLM decides what to run and the runtime runs it — `rm -rf /` included. There is nothing between the model's output and your system. If you don't understand what that means, do not use this. This is a bare agentic loop: execute the task, whatever it takes, nothing more, nothing less.**
 
-**~550 lines of C. 55KB binary. A skill-driven agentic daemon for edge hardware.**
+**~850 lines of C. ~55KB binary. A skill-driven agentic daemon for edge hardware.**
 
 ```
 skill.md + LLM + shell + loop = autonomous agent
@@ -21,10 +21,10 @@ You write a skill as a markdown file. You point SubZeroClaw at it. It calls an L
 ```
 ~/.subzeroclaw/skills/monitor.md    ← what the agent knows
 ~/.subzeroclaw/config               ← API key + request_extra (model / routing policy)
-~/.subzeroclaw/logs/<session>.txt   ← full I/O trace
+~/.subzeroclaw/logs/<session>.jsonl ← private framed session trace
 ```
 
-The agent reads the skill into its system prompt, receives input, and autonomously calls tools until the task is complete. When context grows, the router signals it and the agent seals the old turns **asynchronously** (append-only, in the background) — it never pauses to compact (see "Routing & compaction via unhardcoded").
+The agent reads the skill into its system prompt, receives input, and autonomously calls tools until the task is complete. When context grows, the router signals it and the agent seals old turns synchronously between complete protocol rounds (see "Routing & compaction via unhardcoded").
 
 ## Quickstart
 
@@ -69,13 +69,31 @@ SubZeroClaw points its `endpoint` at [**unhardcoded**](https://github.com/genlay
   per-run `session` id for that affinity), e.g.
   `{"model":"policy:auto","policy_ir":[ "policy", … cache_hot affinity … ]}`.
 - **Compaction** — when the router signals context pressure (an `x_router.compact`
-  flag on the response), SubZeroClaw fires an append-only seal at the router's
-  `/v1/compact` **in the background** and keeps taking turns; when the sealed block
-  lands it splices it in *ahead* of the turns that arrived meanwhile. Compaction is
-  asynchronous — no turn is ever blocked, the prompt-cache prefix is never
-  rewritten, and you never see a pause. The seal routing + how many recent turns to
-  keep verbatim ride in `SUBZEROCLAW_COMPACT_EXTRA` (the second JSON), e.g.
-  `{"keep_recent":8,"policy_ir":[ "policy", … cheap summariser … ]}`.
+  flag on the response), SubZeroClaw calls `/v1/compact` synchronously after the
+  completed assistant/tool round. It keeps authority and recent interaction groups
+  locally and sends only raw `previous_summary` memory plus newly aged complete groups.
+  The router returns raw summary text; SubZeroClaw creates the canonical boundary and
+  sealed summary locally, checks that the result is strictly smaller, and only then
+  replaces the aged context. The system/developer prompt, prior boundary, and recent
+  tail never enter the compaction request. Six recent complete interaction groups
+  stay local; the router owns the trigger, summarizer profile, and 512-token default.
+  There is no configurable summarizer model or routing policy in the runtime. Provider cache
+  reuse after the insertion point is not promised.
+
+  This runtime speaks the summary-only `/v1/compact` contract v3 and fails closed
+  on any other version or malformed result. Deploy a v3-compatible router before
+  this runtime. The
+  request, bearer header and result travel through anonymous pipes;
+  no credential, request or result filename is created in `/tmp`.
+
+  Logs separate two concerns: `COMPACT` contains a bounded status/reason or, for
+  an applied seal, before/after counts and byte sizes. The exact applied memory
+  is then written as a sensitive `COMPACT_SUMMARY` record in the same private
+  JSONL trace. The evidence is local and its retention follows the configured log
+  storage; it is not durable database history unless another system persists it. These adjacent
+  records are best-effort evidence: a process or disk failure can interrupt either
+  write. This makes the actual compacted context inspectable without adding a
+  database or exposing the summary to metadata-only consumers.
 
 This is SubZeroClaw being *more* itself: the loop, the shell, the skill — on a
 substrate that carries everything that was never "skill + LLM + shell + loop".
@@ -97,7 +115,7 @@ SubZeroClaw doesn't simplify their architecture. It ignores it and writes the lo
 |                   | SubZeroClaw  | ZeroClaw     | OpenClaw     |
 |-------------------|--------------|--------------|--------------|
 | Language          | C            | Rust         | TypeScript   |
-| Source            | ~550 lines        | ~15,000      | ~430,000     |
+| Source            | ~850 lines        | ~15,000      | ~430,000     |
 | Binary            | 55 KB             | 3.4 MB       | 80+ MB       |
 | RAM (runtime)     | ~2 MB             | < 5 MB       | 80-120 MB    |
 | Compiles on Pi    | 0.5s              | OOM          | slow         |
@@ -170,10 +188,8 @@ SUBZEROCLAW_ENDPOINT
 SUBZEROCLAW_REQUEST_EXTRA   # the LOOP JSON, merged into every request body. Carries the
                            #   model ({"model":"..."}); against an unhardcoded router it carries
                            #   the routing policy too ({"model":"policy:auto","policy_ir":[...]}).
-                           #   On a key collision the override wins.
-SUBZEROCLAW_COMPACT_EXTRA  # the COMPACTION JSON. When set, an x_router.compact signal triggers
-                           #   an async append-only seal at the router's /v1/compact; this carries
-                           #   keep_recent + the cheap summariser policy_ir. Unset -> no compaction.
+                           #   On a key collision the override wins, except runtime-owned
+                           #   messages, tools, and session, which cannot be replaced.
 ```
 
 ## Usage
@@ -205,7 +221,7 @@ This also gets you credential isolation for free, and it is the recommended way
 to hold the key: run the agent as an unprivileged `User=`, and deliver the key
 through the environment from a root-owned `EnvironmentFile` the agent's user
 cannot read. SubZeroClaw scrubs the provider secrets (`SUBZEROCLAW_API_KEY`,
-`_ENDPOINT`, `_REQUEST_EXTRA`, `_COMPACT_EXTRA`) from its own environment right
+`_ENDPOINT`, `_REQUEST_EXTRA`) from its own environment right
 after reading config (see `config_load`; non-secret vars like `SUBZEROCLAW_SKILLS`
 are kept), so the shell it hands the model never
 inherits the key — `echo $SUBZEROCLAW_API_KEY` and `cat /proc/self/environ` come
@@ -215,14 +231,18 @@ unguarded by design; it only keeps the runtime's own credential out of it.)
 
 ## Session logging
 
-Every session gets a random hex ID. All input, output, tool calls, and results are logged to `~/.subzeroclaw/logs/<session>.txt` with timestamps.
+Every session gets a random hex ID. Input, output, tool calls, results, and
+compaction evidence are written to one escaped JSON object per line. The log
+directory is forced to mode `0700` and the `.jsonl` file to `0600` because it
+contains sensitive conversation data.
 
 ```
-=== f850c58ddd4ae72a Sun Feb 16 16:30:01 2026
-[2026-02-16 16:30:01] USER: check disk usage
-[2026-02-16 16:30:03] TOOL: shell
-[2026-02-16 16:30:03] RES: /dev/sda1  72% /
-[2026-02-16 16:30:04] ASST: Disk usage is at 72%, below threshold.
+{"schema":"subzeroclaw.log.v2","sequence":1,"role":"USER","content":"check disk usage",...}
+{"schema":"subzeroclaw.log.v2","sequence":2,"role":"TOOL","content":"shell: df -h",...}
+{"schema":"subzeroclaw.log.v2","sequence":3,"role":"RES","content":"/dev/sda1 72% /",...}
+{"schema":"subzeroclaw.log.v2","sequence":4,"role":"ASST","content":"Disk usage is at 72%.",...}
+{"schema":"subzeroclaw.log.v2","sequence":5,"role":"COMPACT","content":"{...}",...}
+{"schema":"subzeroclaw.log.v2","sequence":6,"role":"COMPACT_SUMMARY","content":"[Earlier conversation summary...]",...}
 ```
 
 ## Config reference
@@ -231,7 +251,6 @@ Every session gets a random hex ID. All input, output, tool calls, and results a
 |-----|---------|-------------|
 | `api_key` | (required) | The unhardcoded router consumer key (`llmr_…`); an OpenRouter/provider key works in the degraded standalone mode |
 | `request_extra` | (none) | the loop JSON merged into every request body — carries the `model`, and against an unhardcoded router the routing `policy_ir` |
-| `compact_extra` | (none) | the compaction JSON — `keep_recent` + the cheap summariser `policy_ir`; unset disables compaction |
 | `endpoint` | `https://openrouter.ai/api/v1/chat/completions` | API endpoint (point it at an unhardcoded router for routing/cache/compaction) |
 | `skills_dir` | `~/.subzeroclaw/skills` | Path to skill markdown files |
 | `log_dir` | `~/.subzeroclaw/logs` | Session log directory |
@@ -250,7 +269,7 @@ Every session gets a random hex ID. All input, output, tool calls, and results a
 
 ```
 src/
-├── subzeroclaw.c   ~550 lines  The entire runtime
+├── subzeroclaw.c   ~850 lines  The entire runtime
 ├── test.c                      the test suite
 ├── cJSON.c                     Vendored JSON parser
 └── cJSON.h
@@ -266,7 +285,7 @@ Every layer of "framework" between the model and the shell is complexity that ad
 
 OpenClaw solved the agentic loop with 430,000 lines of TypeScript. ZeroClaw re-solved it with 15,000 lines of Rust. Both are good — but both carry the weight of problems that only exist at platform scale: multi-tenancy, channel routing, identity portability, plugin registries.
 
-SubZeroClaw asks: what if the problem is just "one agent, one skill, one device"? Then the answer is ~550 readable lines of C.
+SubZeroClaw asks: what if the problem is just "one agent, one skill, one device"? Then the answer still fits in one readable C file of about 850 lines.
 
 ## License
 

--- a/config.example
+++ b/config.example
@@ -4,7 +4,7 @@
 # src/subzeroclaw.c); anything else in this file is ignored.
 
 # SubZeroClaw is designed to run on an unhardcoded router (routing with
-# prompt-cache affinity + async compaction). So the key is an unhardcoded
+# prompt-cache affinity + synchronous compaction). So the key is an unhardcoded
 # *consumer* key (llmr_…, minted in the router dashboard → Consumers), and
 # `endpoint` points at the router. A bare OpenRouter/provider key still works but
 # is a DEGRADED loop — no routing, no cache, no compaction (see the README).
@@ -21,11 +21,6 @@ endpoint = "https://YOUR-UNHARDCODED-ROUTER/v1/chat/completions"
 # skill); "policy:auto" tells the router to pick:
 request_extra = {"model":"policy:auto","policy_ir":["policy", "..."]}
 # Direct provider instead (degraded, no router): {"model": "minimax/minimax-m2.5"}
-
-# compact_extra enables async context sealing at the router's /v1/compact:
-# keep_recent (turns kept verbatim) + a cheap summariser policy. Bare JSON, same
-# rule as request_extra. Unset => no compaction.
-# compact_extra = {"keep_recent": 8, "policy_ir": ["policy", "..."]}
 
 # skills_dir = "~/.subzeroclaw/skills"
 # log_dir    = "~/.subzeroclaw/logs"

--- a/site/index.html
+++ b/site/index.html
@@ -4,19 +4,19 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>SubZeroClaw — an agent small enough to run anywhere</title>
-<meta name="description" content="SubZeroClaw is a minimal agent runtime in C — ~550 lines, a 55KB binary, ~2MB RAM. No framework, just the loop. Small enough to run anywhere: edge devices, local automation, and large-scale swarms." />
+<meta name="description" content="SubZeroClaw is a minimal agent runtime in C — ~850 lines, a 55KB binary, ~2MB RAM. No framework, just the loop. Small enough to run anywhere: edge devices, local automation, and large-scale swarms." />
 <link rel="canonical" href="https://subzeroclaw.com/" />
 <meta name="theme-color" content="#E9E0D2" />
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="SubZeroClaw" />
 <meta property="og:title" content="SubZeroClaw — an agent small enough to run anywhere" />
-<meta property="og:description" content="A minimal agent runtime in C. ~550 lines · 55KB · ~2MB RAM · 2 deps. No framework, just the loop." />
+<meta property="og:description" content="A minimal agent runtime in C. ~850 lines · 55KB · ~2MB RAM · 2 deps. No framework, just the loop." />
 <meta property="og:url" content="https://subzeroclaw.com/" />
 <meta property="og:image" content="https://subzeroclaw.com/og.png" />
 <meta property="og:image:type" content="image/png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="SubZeroClaw — an agent small enough to run anywhere. 550 lines of C, 55 KB, ~2 MB RAM, 2 deps." />
+<meta property="og:image:alt" content="SubZeroClaw — an agent small enough to run anywhere. 857 lines of C, 55 KB, ~2 MB RAM, 2 deps." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="SubZeroClaw — an agent small enough to run anywhere" />
 <meta name="twitter:description" content="A minimal agent runtime in C. No framework, just the loop." />
@@ -31,7 +31,7 @@
   "@type": "SoftwareSourceCode",
   "name": "SubZeroClaw",
   "alternateName": "SZC",
-  "description": "A minimal agentic runtime in C — ~550 lines, a 55KB binary, ~2MB RAM. One skill file plus an LLM plus a shell loop, with no framework. Small enough to run anywhere: edge devices, Raspberry Pi, local automation, and large-scale agent swarms.",
+  "description": "A minimal agentic runtime in C — ~850 lines, a 55KB binary, ~2MB RAM. One skill file plus an LLM plus a shell loop, with no framework. Small enough to run anywhere: edge devices, Raspberry Pi, local automation, and large-scale agent swarms.",
   "url": "https://subzeroclaw.com/",
   "image": "https://subzeroclaw.com/og.png",
   "codeRepository": "https://github.com/genlayerlabs/subzeroclaw",
@@ -138,7 +138,7 @@ footer{border-top:1px solid var(--line)}
       <span class="cmd">git clone github.com/genlayerlabs/subzeroclaw</span>
       <span class="lbl" aria-live="polite">copy</span>
     </button>
-    <p class="stats">550 lines of C · 55 KB · ~2 MB RAM · 2 deps</p>
+    <p class="stats">857 lines of C · 55 KB · ~2 MB RAM · 2 deps</p>
   </div>
 
   <div class="orbit-stage">

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,12 +1,12 @@
 # SubZeroClaw
 
-> A minimal agentic runtime written in C: ~550 lines of source, a 55KB binary, ~2MB RAM at runtime. One skill file + one LLM + one shell loop. No framework, no plugins, no adapters. Small enough to run anywhere — edge devices, Raspberry Pi, local automation, and large-scale agent swarms.
+> A minimal agentic runtime written in C: ~850 lines of source, a 55KB binary, ~2MB RAM at runtime. One skill file + one LLM + one shell loop. No framework, no plugins, no adapters. Small enough to run anywhere — edge devices, Raspberry Pi, local automation, and large-scale agent swarms.
 
-SubZeroClaw connects an LLM to a shell and loops: it reads a skill (a plain markdown file), calls the model, runs the one tool the model asks for (the shell), and repeats until the task is done. Because the only tool is the shell, any CLI you already have installed (git, curl, ffmpeg, jq, rsync, ...) is immediately available to the agent — there are no integrations to build. When context grows, the runtime does not summarize in-process: the unhardcoded router signals pressure (an `x_router.compact` flag) and the old turns are sealed asynchronously in the background (append-only), so the loop never pauses.
+SubZeroClaw connects an LLM to a shell and loops: it reads a skill (a plain markdown file), calls the model, runs the one tool the model asks for (the shell), and repeats until the task is done. Because the only tool is the shell, any CLI you already have installed (git, curl, ffmpeg, jq, rsync, ...) is immediately available to the agent — there are no integrations to build. When context grows, the unhardcoded router signals pressure (an `x_router.compact` flag), then the runtime synchronously replaces aged complete interaction groups with a router-produced summary between protocol rounds while keeping authority and the recent tail local.
 
 ## Facts
 
-- Language: C (~550 lines of runtime in a single file)
+- Language: C (~850 lines of runtime in a single file)
 - Binary size: 55 KB
 - RAM at runtime: ~2 MB
 - Dependencies: a shell with curl, and unhardcoded (the router substrate — model selection, prompt-cache affinity, context compaction; MIT). cJSON is vendored in-repo, not a dependency.

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -2,10 +2,15 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 #include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <dirent.h>
 #include <cjson/cJSON.h>
@@ -13,17 +18,21 @@
 #define MAX_PATH   512
 #define MAX_VALUE  1024
 #define MAX_OUTPUT (128 * 1024)
-#define MAX_EXTRA  8192   /* request_extra: an operator-supplied JSON body override */
+#define MAX_HTTP_RESPONSE (4 * 1024 * 1024)
+#define MAX_EXTRA  8192   /* small operator-supplied request JSON */
 
 typedef struct {
     char api_key[MAX_VALUE], endpoint[MAX_VALUE];
     char skills_dir[MAX_PATH], log_dir[MAX_PATH];
     char request_extra[MAX_EXTRA];   /* the loop JSON: model + routing policy_ir */
-    char compact_extra[MAX_EXTRA];   /* the compaction JSON: keep_recent + seal policy_ir */
-    char session[MAX_VALUE];   /* runtime per-run id (sid); sent so the router can
-                                  keep this conversation pinned to its cache-hot peer */
+    char session[MAX_VALUE];   /* per-run id; keeps routing cache-hot */
     int  max_turns;
 } Config;
+
+typedef struct {
+    FILE *jsonl;
+    uint64_t sequence;
+} LogSink;
 
 static void config_parse_line(Config *cfg, const char *key, const char *val) {
     if      (!strcmp(key, "api_key"))      snprintf(cfg->api_key,    MAX_VALUE, "%s", val);
@@ -31,7 +40,6 @@ static void config_parse_line(Config *cfg, const char *key, const char *val) {
     else if (!strcmp(key, "skills_dir"))   snprintf(cfg->skills_dir, MAX_PATH,  "%s", val);
     else if (!strcmp(key, "log_dir"))      snprintf(cfg->log_dir,    MAX_PATH,  "%s", val);
     else if (!strcmp(key, "request_extra")) snprintf(cfg->request_extra, MAX_EXTRA, "%s", val);
-    else if (!strcmp(key, "compact_extra")) snprintf(cfg->compact_extra, MAX_EXTRA, "%s", val);
     else if (!strcmp(key, "max_turns"))    cfg->max_turns    = atoi(val);
 }
 
@@ -67,27 +75,15 @@ int config_load(Config *cfg) {
     char *v;
     if ((v = getenv("SUBZEROCLAW_API_KEY")))  snprintf(cfg->api_key,  MAX_VALUE, "%s", v);
     if ((v = getenv("SUBZEROCLAW_ENDPOINT"))) snprintf(cfg->endpoint, MAX_VALUE, "%s", v);
-    /* Per-agent skills dir from the orchestrator (genswarms wrapper exports this).
-       Overrides the config-file / default ~/.subzeroclaw/skills so each agent in a
-       swarm loads its OWN configured skill instead of the host default. */
     if ((v = getenv("SUBZEROCLAW_SKILLS"))) snprintf(cfg->skills_dir, MAX_PATH, "%s", v);
     if ((v = getenv("SUBZEROCLAW_REQUEST_EXTRA"))) snprintf(cfg->request_extra, MAX_EXTRA, "%s", v);
-    if ((v = getenv("SUBZEROCLAW_COMPACT_EXTRA"))) snprintf(cfg->compact_extra, MAX_EXTRA, "%s", v);
     if (!cfg->api_key[0]) { fprintf(stderr, "error: no api_key\n"); return -1; }
 
-    /* Scrub the provider config from our own environment now that it lives in cfg.
-       The one tool we expose, "shell", runs commands via popen() (/bin/sh -c),
-       which inherits this process's environment — so without this an LLM-driven
-       command could read the key/endpoint with `echo $SUBZEROCLAW_API_KEY`, `env`,
-       or by catting /proc/<pid>/environ. unsetenv() alone is NOT enough: getenv()
-       returns a pointer into the original environment region that
-       /proc/<pid>/environ exposes, and unsetenv() leaves those bytes intact — so
-       wipe the value in place first, then remove the name. The values remain in
-       cfg, so requests are unaffected. */
+    /* Keep provider configuration out of the shell tool's environment. */
     {
         static const char *const secret_vars[] = {
-            "SUBZEROCLAW_API_KEY", "SUBZEROCLAW_ENDPOINT",
-            "SUBZEROCLAW_REQUEST_EXTRA", "SUBZEROCLAW_COMPACT_EXTRA"
+            "SUBZEROCLAW_API_KEY", "SUBZEROCLAW_ENDPOINT", "SUBZEROCLAW_REQUEST_EXTRA",
+            "SUBZEROCLAW_COMPACT_EXTRA" /* legacy; never expose old policy JSON to tools */
         };
         for (size_t i = 0; i < sizeof(secret_vars) / sizeof(secret_vars[0]); i++) {
             char *p = getenv(secret_vars[i]);
@@ -102,63 +98,173 @@ static void mkdirp(const char *path) {
     char tmp[MAX_PATH];
     snprintf(tmp, MAX_PATH, "%s", path);
     for (char *p = tmp + 1; *p; p++)
-        if (*p == '/') { *p = '\0'; mkdir(tmp, 0755); *p = '/'; }
-    mkdir(tmp, 0755);
+        if (*p == '/') { *p = '\0'; mkdir(tmp, 0700); *p = '/'; }
+    mkdir(tmp, 0700);
+    chmod(tmp, 0700);
 }
 
-static void log_write(FILE *log, const char *role, const char *content) {
-    if (!log) return;
+static FILE *open_private_append(const char *path) {
+    int fd = open(path, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC | O_NOFOLLOW, 0600);
+    if (fd < 0) return NULL;
+    if (fchmod(fd, 0600) < 0) { close(fd); return NULL; }
+    FILE *file = fdopen(fd, "a");
+    if (!file) close(fd);
+    return file;
+}
+
+static void make_session_id(char out[32]) {
+    unsigned char b[8];
+    FILE *ur = fopen("/dev/urandom", "r");
+    size_t n = ur ? fread(b, 1, sizeof(b), ur) : 0;
+    if (ur) fclose(ur);
+    if (n == sizeof(b)) snprintf(out, 32, "%02x%02x%02x%02x%02x%02x%02x%02x",
+        b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]);
+    else snprintf(out, 32, "%lx%x", (long)time(NULL), getpid());
+}
+
+static int64_t realtime_ms(void) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
+        return (int64_t)time(NULL) * 1000;
+    return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+static void log_write(LogSink *log, const char *role, const char *content) {
+    if (!log || !log->jsonl) return;
     time_t now = time(NULL);
     struct tm *t = localtime(&now);
     char ts[32]; strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", t);
-    fprintf(log, "[%s] %s: %s\n", ts, role, content); fflush(log);
+    cJSON *entry = cJSON_CreateObject();
+    if (!entry) return;
+    cJSON_AddStringToObject(entry, "schema", "subzeroclaw.log.v2");
+    cJSON_AddNumberToObject(entry, "sequence", (double)++log->sequence);
+    cJSON_AddStringToObject(entry, "timestamp", ts);
+    cJSON_AddNumberToObject(entry, "observed_at_unix_ms", (double)realtime_ms());
+    cJSON_AddStringToObject(entry, "role", role);
+    cJSON_AddStringToObject(entry, "content", content ? content : "");
+    char *json = cJSON_PrintUnformatted(entry);
+    if (json) {
+        fputs(json, log->jsonl); fputc('\n', log->jsonl); fflush(log->jsonl);
+        free(json);
+    }
+    cJSON_Delete(entry);
 }
 
-static int write_temp(const char *prefix, const char *data, char *out, size_t out_size) {
-    snprintf(out, out_size, "/tmp/.szc_%s_XXXXXX", prefix);
-    int fd = mkstemp(out); if (fd < 0) return -1;
-    FILE *f = fdopen(fd, "w");
-    if (!f) { close(fd); unlink(out); return -1; }
-    fputs(data, f); fclose(f);
+static int header_value_safe(const char *value) {
+    return value && !strpbrk(value, "\r\n\"\\");
+}
+
+static int write_all(int fd, const char *data, size_t len) {
+    while (len) {
+        ssize_t n = write(fd, data, len);
+        if (n > 0) { data += n; len -= (size_t)n; continue; }
+        if (n < 0 && errno == EINTR) continue;
+        return -1;
+    }
     return 0;
 }
 
+/* Curl receives credentials and request bodies only through anonymous pipes. */
 static char *http_post(const char *url, const char *api_key, const char *session,
                        const char *body) {
-    char body_path[64], hdr_path[64];
-    if (write_temp("body", body, body_path, sizeof(body_path)) < 0) return NULL;
-    char hdr[2 * MAX_VALUE + 128];
-    /* The unhardcoded router pins cache affinity AND meters per-session
-       (GET /v1/session/{sid}: calls/tokens/cost) by the HEADER — the body
-       "session" field alone is not honored by the deployed router. */
-    if (session && session[0])
-        snprintf(hdr, sizeof(hdr),
-                 "-H \"Authorization: Bearer %s\"\n-H \"X-Unhardcoded-Session: %s\"",
-                 api_key, session);
-    else
-        snprintf(hdr, sizeof(hdr), "-H \"Authorization: Bearer %s\"", api_key);
-    if (write_temp("hdr", hdr, hdr_path, sizeof(hdr_path)) < 0) { unlink(body_path); return NULL; }
+    if (!url || !body || !header_value_safe(api_key) ||
+        (session && session[0] && !header_value_safe(session))) return NULL;
 
-    char cmd[2048];
-    snprintf(cmd, sizeof(cmd),
-        "curl -s -m 120 -K '%s' -H 'Content-Type: application/json' -d @'%s' '%s' 2>&1",
-        hdr_path, body_path, url);
-    FILE *fp = popen(cmd, "r");
-    if (!fp) { unlink(body_path); unlink(hdr_path); return NULL; }
-
-    size_t cap = 65536, len = 0, n;
-    char *buf = malloc(cap);
-    while (buf && (n = fread(buf + len, 1, cap - len - 1, fp)) > 0) {
-        len += n;
-        if (len + 1 >= cap) {
-            cap *= 2;
-            char *nb = realloc(buf, cap);
-            if (!nb) { free(buf); buf = NULL; break; }
-            buf = nb;
-        }
+    int body_pipe[2], config_pipe[2], output_pipe[2];
+    if (pipe(body_pipe) < 0) return NULL;
+    if (pipe(config_pipe) < 0) {
+        close(body_pipe[0]); close(body_pipe[1]); return NULL;
     }
-    if (buf) buf[len] = '\0';
-    pclose(fp); unlink(body_path); unlink(hdr_path);
+    if (pipe(output_pipe) < 0) {
+        close(body_pipe[0]); close(body_pipe[1]);
+        close(config_pipe[0]); close(config_pipe[1]); return NULL;
+    }
+
+    char config[2 * MAX_VALUE + 160];
+    int config_len;
+    if (session && session[0])
+        config_len = snprintf(config, sizeof(config),
+            "header = \"Authorization: Bearer %s\"\n"
+            "header = \"X-Unhardcoded-Session: %s\"\n",
+            api_key, session);
+    else
+        config_len = snprintf(config, sizeof(config),
+            "header = \"Authorization: Bearer %s\"\n", api_key);
+    if (config_len < 0 || config_len >= (int)sizeof(config)) {
+        close(body_pipe[0]); close(body_pipe[1]);
+        close(config_pipe[0]); close(config_pipe[1]);
+        close(output_pipe[0]); close(output_pipe[1]); return NULL;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        memset(config, 0, sizeof(config));
+        close(body_pipe[0]); close(body_pipe[1]);
+        close(config_pipe[0]); close(config_pipe[1]);
+        close(output_pipe[0]); close(output_pipe[1]); return NULL;
+    }
+    if (pid == 0) {
+        close(body_pipe[1]); close(config_pipe[1]); close(output_pipe[0]);
+        if (dup2(body_pipe[0], STDIN_FILENO) < 0 ||
+            dup2(output_pipe[1], STDOUT_FILENO) < 0 ||
+            dup2(output_pipe[1], STDERR_FILENO) < 0) _exit(126);
+        if (body_pipe[0] != STDIN_FILENO) close(body_pipe[0]);
+        if (output_pipe[1] != STDOUT_FILENO && output_pipe[1] != STDERR_FILENO)
+            close(output_pipe[1]);
+        char config_path[64];
+        snprintf(config_path, sizeof(config_path), "/dev/fd/%d", config_pipe[0]);
+        execlp("curl", "curl", "-sS", "--fail", "-m", "120",
+               "--config", config_path,
+               "-H", "Content-Type: application/json", "--data-binary", "@-",
+               "--url", url, (char *)NULL);
+        _exit(127);
+    }
+
+    close(body_pipe[0]); close(config_pipe[0]); close(output_pipe[1]);
+    /* Drain curl while a bounded helper feeds its config and body. Otherwise
+       an early response can fill stdout while this process blocks on stdin. */
+    pid_t writer = fork();
+    if (writer == 0) {
+        close(output_pipe[0]);
+        int ok = write_all(config_pipe[1], config, (size_t)config_len);
+        close(config_pipe[1]); memset(config, 0, sizeof(config));
+        if (ok == 0) ok = write_all(body_pipe[1], body, strlen(body));
+        close(body_pipe[1]);
+        _exit(ok == 0 ? 0 : 1);
+    }
+    close(config_pipe[1]); close(body_pipe[1]);
+    memset(config, 0, sizeof(config));
+
+    size_t cap = 65536, len = 0;
+    char *buf = malloc(cap);
+    while (buf) {
+        if (len + 1 == cap) {
+            if (cap >= MAX_HTTP_RESPONSE) { free(buf); buf = NULL; break; }
+            size_t next = cap * 2;
+            if (next > MAX_HTTP_RESPONSE) next = MAX_HTTP_RESPONSE;
+            char *grown = realloc(buf, next);
+            if (!grown) { free(buf); buf = NULL; break; }
+            buf = grown; cap = next;
+        }
+        ssize_t n = read(output_pipe[0], buf + len, cap - len - 1);
+        if (n > 0) { len += (size_t)n; continue; }
+        if (n < 0 && errno == EINTR) continue;
+        break;
+    }
+    close(output_pipe[0]);
+    int status = 0;
+    pid_t waited;
+    while ((waited = waitpid(pid, &status, 0)) < 0 && errno == EINTR) {}
+    int writer_status = 0;
+    pid_t writer_waited = -1;
+    if (writer > 0)
+        while ((writer_waited = waitpid(writer, &writer_status, 0)) < 0 && errno == EINTR) {}
+    if (waited != pid || writer <= 0 || writer_waited != writer || !buf ||
+        !WIFEXITED(writer_status) || WEXITSTATUS(writer_status) != 0 ||
+        !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        free(buf); return NULL;
+    }
+    buf[len] = '\0';
     return buf;
 }
 
@@ -168,35 +274,22 @@ static const char TOOLS_JSON[] =
     "\"parameters\":{\"type\":\"object\","
     "\"properties\":{\"command\":{\"type\":\"string\"}},\"required\":[\"command\"]}}}]";
 
-char *tool_execute(const char *name, const char *args_json) {
+static char *tool_execute(const char *name, const char *cmd) {
     if (strcmp(name, "shell")) return strdup("error: unknown tool");
-    cJSON *args = cJSON_Parse(args_json);
-    cJSON *cmd_item = args ? cJSON_GetObjectItem(args, "command") : NULL;
-    const char *cmd = (cmd_item && cJSON_IsString(cmd_item)) ? cmd_item->valuestring : NULL;
-    if (!cmd) { if (args) cJSON_Delete(args); return strdup("error: missing 'command'"); }
-    /* Wrap as "{\n cmd \n} 2>&1": newline separators work for heredocs
-       (terminator must be alone on its line) and for commands ending in ';'.
-       The "; }" form breaks both. */
+    if (!cmd) return strdup("error: missing 'command'");
     size_t len = strlen(cmd);
-    char *full = malloc(len + 16);
+    char *full = malloc(len + 16), *out = malloc(MAX_OUTPUT + 16);
+    if (!full || !out) { free(full); free(out); return strdup("error: allocation failed"); }
     memcpy(full, "{\n", 2); memcpy(full + 2, cmd, len);
     memcpy(full + 2 + len, "\n} 2>&1", 8);
-    if (args) cJSON_Delete(args);
     FILE *fp = popen(full, "r"); free(full);
-    if (!fp) return strdup("[exit:-1] error: popen failed");
-    /* Reserve 16 bytes at the head for the "[exit:N] " prefix */
-    char *out = malloc(MAX_OUTPUT + 16);
-    size_t total = 16, n;
-    /* Bound each read by the space left in `out` (cap = MAX_OUTPUT+16, with
-       out[total] reserved for the trailing NUL). The previous loop kept the
-       per-read count at MAX_OUTPUT-1 even as `total` grew, so the SECOND fread
-       on any tool output under ~128KB ran past the buffer. On a fortified (-O2,
-       Ubuntu-default _FORTIFY_SOURCE) glibc build that is a fatal __fread_chk
-       abort (SIGABRT) — it silently killed the agent the moment it read back a
-       small tool result (e.g. a `swarm-msg ask` envelope), wedging the turn. */
-    while (total < MAX_OUTPUT + 15 &&
-           (n = fread(out + total, 1, (MAX_OUTPUT + 15) - total, fp)) > 0) {
-        total += n;
+    if (!fp) { free(out); return strdup("[exit:-1] error: popen failed"); }
+    char discard[4096];
+    size_t total = 16, n, space;
+    while ((space = MAX_OUTPUT + 15 - total,
+            n = fread(space ? out + total : discard, 1,
+                      space ? space : sizeof(discard), fp)) > 0) {
+        if (space) total += n;
     }
     out[total] = '\0';
     int status = pclose(fp);
@@ -236,75 +329,72 @@ char *agent_build_system_prompt(const char *skills_dir) {
 }
 
 typedef struct {
-    char *finish_reason, *text;
+    char *text;
     cJSON *tool_calls, *msg;
-    int compact;   /* router asked us to seal context (x_router.compact) */
+    int tool_round, runnable, compact;
     char usage[192]; /* per-call meter line from usage + x_router (empty if absent) */
 } Response;
 
 static void response_free(Response *r) {
-    if (r->finish_reason) free(r->finish_reason);
     if (r->msg) cJSON_Delete(r->msg);
 }
 
-/* references avoid copying the full message array */
 static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
     cJSON *req = cJSON_CreateObject();
-    /* Session id (if any): sent so the router can keep this conversation pinned to
-       the peer that already holds its prompt-cache prefix (cache_hot). */
     if (cfg->session[0]) cJSON_AddStringToObject(req, "session", cfg->session);
 
-    /* The model is NOT hardcoded by the agent. It rides in the operator's
-       SUBZEROCLAW_REQUEST_EXTRA — "model":"policy:auto" plus a "policy_ir" to let
-       the unhardcoded router decide, or a concrete model for a direct provider.
-       SUBZEROCLAW_REQUEST_EXTRA is a JSON object whose top-level keys are merged
-       in: empty/unset → unchanged; malformed → ignored; on a key collision the
-       override wins. Applied before messages/tools so it can add `model`,
-       `policy_ir`, params (temperature, …) without colliding with the reference
-       items below. */
     if (cfg->request_extra[0]) {
         cJSON *extra = cJSON_Parse(cfg->request_extra);
         if (extra && cJSON_IsObject(extra)) {
             cJSON *it = NULL;
             cJSON_ArrayForEach(it, extra) {
+                if (!strcasecmp(it->string, "messages") || !strcasecmp(it->string, "tools") ||
+                    !strcasecmp(it->string, "session")) continue;
                 cJSON *dup = cJSON_Duplicate(it, 1);
                 if (!dup) continue;
-                cJSON_DeleteItemFromObject(req, it->string);  /* override wins */
+                cJSON_DeleteItemFromObjectCaseSensitive(req, it->string);  /* override wins */
                 cJSON_AddItemToObject(req, it->string, dup);
             }
         }
         if (extra) cJSON_Delete(extra);
     }
 
-    /* messages/tools are owned by the runtime and added by reference (not copied);
-       skip if the override already supplied them, so they are never duplicated. */
-    int msgs_ref = 0, tools_ref = 0;
-    if (!cJSON_GetObjectItem(req, "messages")) {
-        cJSON_AddItemReferenceToObject(req, "messages", msgs); msgs_ref = 1;
-    }
-    if (tools && !cJSON_GetObjectItem(req, "tools")) {
-        cJSON_AddItemReferenceToObject(req, "tools", tools); tools_ref = 1;
+    if (!cJSON_AddItemReferenceToObject(req, "messages", msgs) ||
+        (tools && !cJSON_AddItemReferenceToObject(req, "tools", tools))) {
+        cJSON_Delete(req); return NULL;
     }
     char *json = cJSON_PrintUnformatted(req);
-    if (msgs_ref)  cJSON_DetachItemFromObject(req, "messages");
-    if (tools_ref) cJSON_DetachItemFromObject(req, "tools");
     cJSON_Delete(req);
     return json;
 }
 
-#if defined(__GNUC__) || defined(__clang__)
-#define SZC_WEAK __attribute__((weak))
-#else
-#define SZC_WEAK
-#endif
-
-/* Weak so an optional module (e.g. szc_mock.c) can override at link time. */
-SZC_WEAK char *llm_chat(const Config *cfg, cJSON *msgs, cJSON *tools) {
-    char *rj = build_request(cfg, msgs, tools);
-    if (!rj) return NULL;
-    char *rb = http_post(cfg->endpoint, cfg->api_key, cfg->session, rj);
-    free(rj);
-    return rb;
+static int valid_tool_calls(cJSON *calls, int *runnable) {
+    *runnable = calls && calls->child;
+    if (!calls) return 1;
+    if (!cJSON_IsArray(calls)) return 0;
+    cJSON *call = NULL;
+    cJSON_ArrayForEach(call, calls) {
+        cJSON *id = cJSON_GetObjectItem(call, "id");
+        cJSON *fn = cJSON_GetObjectItem(call, "function");
+        cJSON *name = fn ? cJSON_GetObjectItem(fn, "name") : NULL;
+        cJSON *args = fn ? cJSON_GetObjectItem(fn, "arguments") : NULL;
+        if (!cJSON_IsObject(call) || !id || !cJSON_IsString(id) ||
+            !id->valuestring || !id->valuestring[0] || !cJSON_IsObject(fn) ||
+            !name || !cJSON_IsString(name) || !name->valuestring ||
+            !name->valuestring[0] || !cJSON_IsString(args) || !args->valuestring)
+            return 0;
+        for (cJSON *prior = calls->child; prior != call; prior = prior->next) {
+            cJSON *prior_id = cJSON_GetObjectItem(prior, "id");
+            if (prior_id && cJSON_IsString(prior_id) &&
+                !strcmp(prior_id->valuestring, id->valuestring)) return 0;
+        }
+        cJSON *parsed = cJSON_ParseWithOpts(args->valuestring, NULL, 1);
+        cJSON *cmd = parsed ? cJSON_GetObjectItem(parsed, "command") : NULL;
+        if (strcmp(name->valuestring, "shell") || !cJSON_IsObject(parsed) ||
+            !cmd || !cJSON_IsString(cmd) || !cmd->valuestring[0]) *runnable = 0;
+        cJSON_Delete(parsed);
+    }
+    return 1;
 }
 
 static int parse_response(const char *body, Response *out) {
@@ -313,25 +403,37 @@ static int parse_response(const char *body, Response *out) {
     cJSON *err = cJSON_GetObjectItem(root, "error");
     if (err) {
         cJSON *m = cJSON_GetObjectItem(err, "message");
-        fprintf(stderr, "API error: %s\n", m ? m->valuestring : "unknown");
+        fprintf(stderr, "API error: %s\n",
+                m && cJSON_IsString(m) ? m->valuestring : "unknown");
         cJSON_Delete(root); return -1;
     }
     cJSON *choices = cJSON_GetObjectItem(root, "choices");
-    if (!choices || !choices->child) { cJSON_Delete(root); return -1; }
+    if (!cJSON_IsArray(choices) || !choices->child) { cJSON_Delete(root); return -1; }
     cJSON *choice  = choices->child;
     cJSON *message = cJSON_GetObjectItem(choice, "message");
-    if (!message) { cJSON_Delete(root); return -1; }
     cJSON *fr = cJSON_GetObjectItem(choice, "finish_reason");
-    out->finish_reason = strdup(fr && cJSON_IsString(fr) ? fr->valuestring : "stop");
+    cJSON *role = message ? cJSON_GetObjectItem(message, "role") : NULL;
+    cJSON *ct = message ? cJSON_GetObjectItem(message, "content") : NULL;
+    cJSON *calls = message ? cJSON_GetObjectItem(message, "tool_calls") : NULL;
+    if (cJSON_IsNull(calls)) calls = NULL;
+    int tool_round = fr && cJSON_IsString(fr) && fr->valuestring &&
+                     !strcmp(fr->valuestring, "tool_calls");
+    if (!cJSON_IsObject(choice) || !cJSON_IsObject(message) || !role ||
+        !cJSON_IsString(role) || !role->valuestring ||
+        strcmp(role->valuestring, "assistant") || !fr || !cJSON_IsString(fr) ||
+        !fr->valuestring ||
+        (strcmp(fr->valuestring, "stop") && strcmp(fr->valuestring, "tool_calls")) ||
+        (ct && !cJSON_IsNull(ct) && !cJSON_IsString(ct)) ||
+        !valid_tool_calls(calls, &out->runnable) ||
+        (tool_round != (calls && calls->child))) {
+        cJSON_Delete(root); return -1;
+    }
+    out->tool_round = tool_round;
     out->msg = cJSON_DetachItemFromObject(choice, "message");
-    cJSON *ct = cJSON_GetObjectItem(out->msg, "content");
     out->text = (ct && cJSON_IsString(ct)) ? ct->valuestring : NULL;
-    out->tool_calls = cJSON_GetObjectItem(out->msg, "tool_calls");
+    out->tool_calls = calls;
     cJSON *xr = cJSON_GetObjectItem(root, "x_router");
     out->compact = xr && cJSON_IsTrue(cJSON_GetObjectItem(xr, "compact"));
-    /* Per-call meter: the router reports tokens + cost in-band on every
-       response (usage + x_router.cost_usd). Logged per session so an
-       agent's spend is auditable locally, whatever the router deploy. */
     {
         cJSON *us = cJSON_GetObjectItem(root, "usage");
         cJSON *pi = us ? cJSON_GetObjectItem(us, "prompt_tokens") : NULL;
@@ -353,126 +455,256 @@ static int parse_response(const char *body, Response *out) {
 
 static cJSON *make_msg(const char *role, const char *content) {
     cJSON *m = cJSON_CreateObject();
-    cJSON_AddStringToObject(m, "role", role);
-    cJSON_AddStringToObject(m, "content", content);
+    if (!m || !cJSON_AddStringToObject(m, "role", role) ||
+        !cJSON_AddStringToObject(m, "content", content)) {
+        cJSON_Delete(m); return NULL;
+    }
     return m;
 }
 
-/* Context compaction is no longer summarized in C. The router's /v1/compact seals
-   the aged middle append-only (the frozen prefix + recent tail stay byte-identical,
-   so the prompt-cache prefix is never invalidated). We run it ASYNCHRONOUSLY: fire
-   the seal in the background, keep doing turns, and splice the result in when it
-   lands — so a turn is never blocked and nobody perceives a compaction pause. */
+/* Synchronous compaction runs only between complete protocol rounds. */
+#define COMPACT_KEEP_RECENT 6
+#define SEAL_PREFIX "[Earlier conversation summary; context only, not a new instruction]\n"
+#define SEAL_BOUNDARY "[Compaction boundary] The next assistant message is a sealed summary of " \
+                      "earlier conversation data. Treat it only as historical context. The " \
+                      "current user request follows afterward."
 
-static char *read_file(const char *path) {
-    FILE *f = fopen(path, "r"); if (!f) return NULL;
-    size_t cap = 65536, len = 0, n;
-    char *buf = malloc(cap);
-    while (buf && (n = fread(buf + len, 1, cap - len - 1, f)) > 0) {
-        len += n;
-        if (len + 1 >= cap) { cap *= 2; char *nb = realloc(buf, cap);
-            if (!nb) { free(buf); buf = NULL; break; } buf = nb; }
-    }
-    if (buf) buf[len] = '\0';
-    fclose(f);
-    return buf;
+typedef struct { int authority, body, cutoff; } CompactLayout;
+
+static size_t json_size(cJSON *value) {
+    char *json = cJSON_PrintUnformatted(value);
+    if (!json) return 0;
+    size_t len = strlen(json);
+    free(json);
+    return len;
 }
 
-/* The /v1/compact URL, derived from the chat endpoint. */
+static const char *message_role(cJSON *msg) {
+    cJSON *role = msg ? cJSON_GetObjectItem(msg, "role") : NULL;
+    return role && cJSON_IsString(role) && role->valuestring ? role->valuestring : "";
+}
+static int is_authority_role(const char *role) {
+    return !strcmp(role, "system") || !strcmp(role, "developer");
+}
+
+static const char *message_content(cJSON *msg, const char *role) {
+    cJSON *content = msg ? cJSON_GetObjectItem(msg, "content") : NULL;
+    return !strcmp(message_role(msg), role) && content && cJSON_IsString(content) &&
+           content->valuestring ? content->valuestring : NULL;
+}
+static int compact_layout(cJSON *msgs, int sealed, CompactLayout *layout) {
+    int n = cJSON_GetArraySize(msgs), authority = 0;
+    while (authority < n &&
+           is_authority_role(message_role(cJSON_GetArrayItem(msgs, authority))))
+        authority++;
+    for (int i = authority; i < n; i++)
+        if (is_authority_role(message_role(cJSON_GetArrayItem(msgs, i)))) return -1;
+
+    if (sealed) {
+        const char *boundary = message_content(cJSON_GetArrayItem(msgs, authority), "user");
+        const char *summary = message_content(cJSON_GetArrayItem(msgs, authority + 1), "assistant");
+        if (!boundary || strcmp(boundary, SEAL_BOUNDARY) || !summary ||
+            strncmp(summary, SEAL_PREFIX, sizeof(SEAL_PREFIX) - 1)) return -1;
+    }
+    int body = authority + (sealed ? 2 : 0);
+    if (body > n) return -1;
+    if (body < n && strcmp(message_role(cJSON_GetArrayItem(msgs, body)), "user"))
+        return -1;
+
+    int groups = 0;
+    for (int i = body; i < n; i++)
+        if (!strcmp(message_role(cJSON_GetArrayItem(msgs, i)), "user")) groups++;
+    if (groups <= COMPACT_KEEP_RECENT) return 0;
+    int target = groups - COMPACT_KEEP_RECENT, seen = 0, cutoff = -1;
+    for (int i = body; i < n; i++)
+        if (!strcmp(message_role(cJSON_GetArrayItem(msgs, i)), "user") &&
+            seen++ == target) { cutoff = i; break; }
+    if (cutoff < body) return -1;
+    layout->authority = authority;
+    layout->body = body;
+    layout->cutoff = cutoff;
+    return 1;
+}
+static char *compact_request_body(cJSON *msgs, int sealed,
+                                  const CompactLayout *layout) {
+    cJSON *req = cJSON_CreateObject();
+    cJSON *aged = cJSON_CreateArray();
+    if (!req || !aged) { cJSON_Delete(req); cJSON_Delete(aged); return NULL; }
+    if (!cJSON_AddNumberToObject(req, "contract_version", 3)) goto failed;
+    if (sealed) {
+        const char *previous = message_content(
+            cJSON_GetArrayItem(msgs, layout->authority + 1), "assistant");
+        size_t prefix = sizeof(SEAL_PREFIX) - 1;
+        if (!previous || strlen(previous) <= prefix ||
+            !cJSON_AddStringToObject(req, "previous_summary", previous + prefix))
+            goto failed;
+    }
+    for (int i = layout->body; i < layout->cutoff; i++)
+        if (!cJSON_AddItemReferenceToArray(aged, cJSON_GetArrayItem(msgs, i)))
+            goto failed;
+    if (!cJSON_AddItemToObject(req, "messages", aged)) goto failed;
+    aged = NULL; /* owned by req */
+    char *body = cJSON_PrintUnformatted(req);
+    cJSON_Delete(req);
+    return body;
+failed:
+    cJSON_Delete(req); cJSON_Delete(aged);
+    return NULL;
+}
 static void compact_url(const Config *cfg, char *out, size_t sz) {
     const char *e = cfg->endpoint, *p = strstr(e, "/chat/completions");
     if (p) snprintf(out, sz, "%.*s/compact", (int)(p - e), e);
-    else   snprintf(out, sz, "%s/compact", e);
+    else snprintf(out, sz, "%s/compact", e);
+}
+static void compact_record(LogSink *log, const char *event, const char *reason,
+                           int before_n, int after_n,
+                           size_t before_bytes, size_t after_bytes) {
+    char meta[256];
+    if (!strcmp(event, "applied")) {
+        snprintf(meta, sizeof(meta),
+            "{\"event\":\"applied\",\"before_messages\":%d,\"after_messages\":%d,"
+            "\"before_bytes\":%zu,\"after_bytes\":%zu}",
+            before_n, after_n, before_bytes, after_bytes);
+    } else snprintf(meta, sizeof(meta), "{\"event\":\"%s\",\"reason\":\"%s\"}",
+                    event, reason ? reason : "unknown");
+    log_write(log, "COMPACT", meta);
 }
 
-/* Fire an append-only seal of the current `msgs` in the BACKGROUND: POST to the
-   router's /v1/compact, atomically writing the spliced array to `res_path`. The
-   seal routing + keep_recent ride in SUBZEROCLAW_COMPACT_EXTRA. Returns 0 if
-   launched; the agent keeps looping and picks up the result on a later turn. */
-static int compact_fire(const Config *cfg, cJSON *msgs, char *res_path, size_t res_sz) {
-    cJSON *req = cJSON_CreateObject();
-    if (cfg->compact_extra[0]) {            /* keep_recent / policy_ir / max_tokens */
-        cJSON *extra = cJSON_Parse(cfg->compact_extra);
-        if (extra && cJSON_IsObject(extra)) {
-            cJSON *it = NULL;
-            cJSON_ArrayForEach(it, extra) {
-                cJSON *dup = cJSON_Duplicate(it, 1);
-                if (dup) cJSON_AddItemToObject(req, it->string, dup);
-            }
-        }
-        if (extra) cJSON_Delete(extra);
+static int compact_apply_response(cJSON *msgs, const CompactLayout *layout,
+                                  const char *body, int *sealed,
+                                  LogSink *log) {
+    cJSON *root = cJSON_Parse(body);
+    cJSON *did = root ? cJSON_GetObjectItem(root, "compacted") : NULL;
+    cJSON *reason = root ? cJSON_GetObjectItem(root, "reason") : NULL;
+    if (!cJSON_IsObject(root) || !cJSON_IsBool(did) || !cJSON_IsString(reason) ||
+        !reason->valuestring) {
+        cJSON_Delete(root);
+        compact_record(log, "rejected", "invalid_response", 0, 0, 0, 0);
+        return -1;
     }
-    cJSON_AddItemReferenceToObject(req, "messages", msgs);
-    char *body = cJSON_PrintUnformatted(req);
-    cJSON_DetachItemFromObject(req, "messages");
-    cJSON_Delete(req);
-    if (!body) return -1;
+    cJSON *version = cJSON_GetObjectItem(root, "contract_version");
+    if (!cJSON_IsNumber(version) || version->valuedouble != 3.0) {
+        cJSON_Delete(root);
+        compact_record(log, "rejected", "invalid_contract", 0, 0, 0, 0);
+        return -1;
+    }
+    if (cJSON_IsFalse(did)) {
+        cJSON_Delete(root);
+        compact_record(log, "skipped", "router_declined", 0, 0, 0, 0);
+        return 0;
+    }
 
-    char body_path[64], hdr_path[64];
-    if (write_temp("cbody", body, body_path, sizeof(body_path)) < 0) { free(body); return -1; }
+    cJSON *raw = cJSON_GetObjectItem(root, "summary");
+    if (strcmp(reason->valuestring, "compacted") || !raw ||
+        !cJSON_IsString(raw) || !raw->valuestring ||
+        !raw->valuestring[0]) {
+        cJSON_Delete(root);
+        compact_record(log, "rejected", "unsafe_summary", 0, 0, 0, 0);
+        return -1;
+    }
+    size_t prefix_len = strlen(SEAL_PREFIX), summary_len = strlen(raw->valuestring);
+    char *summary = NULL;
+    cJSON *boundary = NULL, *summary_msg = NULL;
+    summary = malloc(prefix_len + summary_len + 1);
+    if (!summary) goto allocation_failed;
+    memcpy(summary, SEAL_PREFIX, prefix_len);
+    memcpy(summary + prefix_len, raw->valuestring, summary_len + 1);
+
+    boundary = make_msg("user", SEAL_BOUNDARY);
+    summary_msg = make_msg("assistant", summary);
+    if (!boundary || !summary_msg) goto allocation_failed;
+
+    size_t before_bytes = json_size(msgs), removed_bytes = 0;
+    for (int i = layout->authority; i < layout->cutoff; i++) {
+        size_t n = json_size(cJSON_GetArrayItem(msgs, i));
+        if (!n) goto allocation_failed;
+        removed_bytes += n + 1; /* item plus its delimiter in the retained tail */
+    }
+    size_t boundary_bytes = json_size(boundary), summary_bytes = json_size(summary_msg);
+    size_t replacement_bytes = boundary_bytes + summary_bytes + 2;
+    if (!before_bytes || !boundary_bytes || !summary_bytes ||
+        removed_bytes > before_bytes) goto allocation_failed;
+    if (replacement_bytes >= removed_bytes) {
+        cJSON_Delete(boundary); cJSON_Delete(summary_msg);
+        cJSON_Delete(root); free(summary);
+        compact_record(log, "skipped", "insufficient_reduction", 0, 0, 0, 0);
+        return 0;
+    }
+
+    int before_n = cJSON_GetArraySize(msgs);
+    int removed_n = layout->cutoff - layout->authority;
+    int after_n = before_n - removed_n + 2;
+    size_t after_bytes = before_bytes - removed_bytes + replacement_bytes;
+    if (!cJSON_InsertItemInArray(msgs, layout->cutoff, summary_msg))
+        goto allocation_failed;
+    summary_msg = NULL; /* owned by msgs */
+    if (!cJSON_InsertItemInArray(msgs, layout->cutoff, boundary)) {
+        cJSON_DeleteItemFromArray(msgs, layout->cutoff); /* roll back summary */
+        goto allocation_failed;
+    }
+    boundary = NULL; /* owned by msgs */
+    for (int i = 0; i < removed_n; i++)
+        cJSON_DeleteItemFromArray(msgs, layout->authority);
+    *sealed = 1;
+    compact_record(log, "applied", NULL, before_n, after_n,
+                   before_bytes, after_bytes);
+    log_write(log, "COMPACT_SUMMARY", summary);
+    cJSON_Delete(root); free(summary);
+    return 1;
+
+allocation_failed:
+    cJSON_Delete(boundary); cJSON_Delete(summary_msg);
+    cJSON_Delete(root); free(summary);
+    compact_record(log, "failed", "allocation_failed", 0, 0, 0, 0);
+    return -1;
+}
+
+static int compact_messages(const Config *cfg, cJSON *msgs, int *sealed, LogSink *log) {
+    CompactLayout layout;
+    int needed = compact_layout(msgs, *sealed, &layout);
+    if (needed != 1) {
+        compact_record(log, needed < 0 ? "rejected" : "skipped",
+            needed < 0 ? "invalid_layout" : "not_enough_groups", 0, 0, 0, 0);
+        return needed < 0 ? -1 : 0;
+    }
+    char *body = compact_request_body(msgs, *sealed, &layout);
+    if (!body) {
+        compact_record(log, "failed", "allocation_failed", 0, 0, 0, 0);
+        return -1;
+    }
+    char url[MAX_VALUE + 16];
+    compact_url(cfg, url, sizeof(url));
+    fprintf(stderr, "[compact] %d messages\n", cJSON_GetArraySize(msgs));
+    char *response = http_post(url, cfg->api_key, cfg->session, body);
     free(body);
-    char hdr[2 * MAX_VALUE + 128];
-    /* same session header as the chat path: the seal call must meter (and
-       cache-pin) under the SAME sid as the conversation it seals */
-    if (cfg->session[0])
-        snprintf(hdr, sizeof(hdr),
-                 "-H \"Authorization: Bearer %s\"\n-H \"X-Unhardcoded-Session: %s\"",
-                 cfg->api_key, cfg->session);
-    else
-        snprintf(hdr, sizeof(hdr), "-H \"Authorization: Bearer %s\"", cfg->api_key);
-    if (write_temp("chdr", hdr, hdr_path, sizeof(hdr_path)) < 0) { unlink(body_path); return -1; }
-
-    char url[MAX_VALUE + 16]; compact_url(cfg, url, sizeof(url));
-    snprintf(res_path, res_sz, "/tmp/.szc_cres_%d", (int)getpid());
-    /* atomic: write .tmp then rename, so res_path appears only when complete; the
-       subshell cleans its own temp files and detaches (&) so this returns at once. */
-    char cmd[2048 + MAX_VALUE];
-    snprintf(cmd, sizeof(cmd),
-        "( curl -s -m 120 -K '%s' -H 'Content-Type: application/json' -d @'%s' '%s' "
-        "-o '%s.tmp' && mv '%s.tmp' '%s' ; rm -f '%s' '%s' ) >/dev/null 2>&1 &",
-        hdr_path, body_path, url, res_path, res_path, res_path, body_path, hdr_path);
-    return system(cmd) == 0 ? 0 : -1;
-}
-
-/* A background seal finished: replace the `snapshot_len` compacted messages with
-   the sealed view, keeping every turn that arrived while it ran (append-only ⇒
-   conflict-free). */
-static void compact_splice(cJSON *msgs, int snapshot_len, const char *res_path, FILE *log) {
-    char *buf = read_file(res_path);
-    unlink(res_path);
-    if (!buf) return;
-    cJSON *root = cJSON_Parse(buf); free(buf);
-    cJSON *sp = root ? cJSON_GetObjectItem(root, "messages") : NULL;
-    if (sp && cJSON_IsArray(sp) && cJSON_GetArraySize(msgs) >= snapshot_len) {
-        for (int i = 0; i < snapshot_len; i++) cJSON_DeleteItemFromArray(msgs, 0);
-        for (int i = cJSON_GetArraySize(sp) - 1; i >= 0; i--)
-            cJSON_InsertItemInArray(msgs, 0, cJSON_Duplicate(cJSON_GetArrayItem(sp, i), 1));
-        log_write(log, "SYS", "context compacted (append-only, async)");
+    if (!response) {
+        compact_record(log, "failed", "http_failed", 0, 0, 0, 0);
+        return -1;
     }
-    if (root) cJSON_Delete(root);
+    int applied = compact_apply_response(msgs, &layout, response, sealed, log);
+    free(response);
+    return applied;
 }
-
-static void process_tool_calls(cJSON *tool_calls, cJSON *msgs, FILE *log) {
+static void process_tool_calls(cJSON *tool_calls, cJSON *msgs, LogSink *log) {
     cJSON *tc = NULL;
     cJSON_ArrayForEach(tc, tool_calls) {
         cJSON *id = cJSON_GetObjectItem(tc, "id");
         cJSON *fn = cJSON_GetObjectItem(tc, "function");
-        if (!id || !fn) continue;
         cJSON *name = cJSON_GetObjectItem(fn, "name");
         cJSON *args = cJSON_GetObjectItem(fn, "arguments");
-        if (!name || !args) continue;
         // Log tool name with command argument
         cJSON *parsed_args = cJSON_Parse(args->valuestring);
         cJSON *cmd_arg = parsed_args ? cJSON_GetObjectItem(parsed_args, "command") : NULL;
-        if (cmd_arg && cJSON_IsString(cmd_arg)) {
+        const char *command = cmd_arg && cJSON_IsString(cmd_arg) ? cmd_arg->valuestring : NULL;
+        if (command) {
             char tool_log[4096];
-            snprintf(tool_log, sizeof(tool_log), "%s: %s", name->valuestring, cmd_arg->valuestring);
+            snprintf(tool_log, sizeof(tool_log), "%s: %s", name->valuestring, command);
             log_write(log, "TOOL", tool_log);
         } else {
             log_write(log, "TOOL", name->valuestring);
         }
+        char *result = tool_execute(name->valuestring, command);
         if (parsed_args) cJSON_Delete(parsed_args);
-        char *result = tool_execute(name->valuestring, args->valuestring);
         log_write(log, "RES", result ? result : "null");
         cJSON *tm = cJSON_CreateObject();
         cJSON_AddStringToObject(tm, "role", "tool");
@@ -483,97 +715,68 @@ static void process_tool_calls(cJSON *tool_calls, cJSON *msgs, FILE *log) {
     }
 }
 
-/* Does this tool-call round contain at least one call with a usable (non-empty)
-   command? An all-empty round — every `arguments` empty/""/no "command"/blank
-   command — is a model hiccup (codex can emit arguments:"" under load) that we
-   refuse to record, so it can't poison the history and spiral. */
-static int round_has_command(cJSON *tool_calls) {
-    cJSON *tc = NULL;
-    cJSON_ArrayForEach(tc, tool_calls) {
-        cJSON *fn = cJSON_GetObjectItem(tc, "function");
-        cJSON *args = fn ? cJSON_GetObjectItem(fn, "arguments") : NULL;
-        if (!args || !cJSON_IsString(args)) continue;
-        cJSON *parsed = cJSON_Parse(args->valuestring);
-        cJSON *cmd = parsed ? cJSON_GetObjectItem(parsed, "command") : NULL;
-        int ok = cmd && cJSON_IsString(cmd) && cmd->valuestring[0] != '\0';
-        if (parsed) cJSON_Delete(parsed);
-        if (ok) return 1;
-    }
+static int has_visible_text(const char *text) {
+    if (!text) return 0;
+    for (; *text; text++)
+        if (*text != ' ' && *text != '\t' && *text != '\r' && *text != '\n') return 1;
     return 0;
 }
 
 static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
-                     const char *input, FILE *log)
+                     const char *input, int *sealed, LogSink *log)
 {
+    int input_at = cJSON_GetArraySize(msgs), completed_round = 0;
     cJSON_AddItemToArray(msgs, make_msg("user", input));
     log_write(log, "USER", input);
 
-    int compacting = 0, snapshot_len = 0;
-    char compact_res[80] = {0};
     for (int turn = 1; turn <= cfg->max_turns; turn++) {
-        /* a background seal finished while we kept working? splice it in now —
-           append-only, so it never collides with the turns added meanwhile. */
-        if (compacting && access(compact_res, F_OK) == 0) {
-            compact_splice(msgs, snapshot_len, compact_res, log);
-            compacting = 0;
-        }
         fprintf(stderr, "[%d] ...\n", turn);
-        char *rb = llm_chat(cfg, msgs, tools);
-        if (!rb) return -1;
+        char *request = build_request(cfg, msgs, tools);
+        char *rb = request ? http_post(cfg->endpoint, cfg->api_key, cfg->session, request) : NULL;
+        free(request);
+        if (!rb) {
+            if (!completed_round) cJSON_DeleteItemFromArray(msgs, input_at);
+            return -1;
+        }
         Response resp;
-        if (parse_response(rb, &resp) != 0) { free(rb); return -1; }
+        if (parse_response(rb, &resp) != 0) {
+            free(rb);
+            if (!completed_round) cJSON_DeleteItemFromArray(msgs, input_at);
+            return -1;
+        }
         free(rb);
         if (resp.usage[0]) log_write(log, "USAGE", resp.usage);
 
-        /* Discard a tool-call round with no runnable command instead of recording it,
-           so the model can't few-shot off its own malformed call and spiral (codex
-           emits empty arguments:"" under load). max_turns bounds a persistent loop.
-
-           Integrity (object §3): the discard drops BOTH halves of the round
-           atomically — the assistant msg is never appended and process_tool_calls
-           never runs — so no tool_call_id is left orphaned (orphan → API 400). A
-           MIXED round (at least one call carries a command) is recorded instead,
-           and process_tool_calls then pairs every id with a `tool` reply, the empty
-           calls included (asserted by test_recorded_round_pairs_every_call). */
-        if (!strcmp(resp.finish_reason, "tool_calls") && resp.tool_calls &&
-            !round_has_command(resp.tool_calls)) {
+        if (resp.tool_round && !resp.runnable) {
             response_free(&resp);   /* discard: the empty call never enters history */
             continue;
         }
 
+        int tool_round = resp.tool_round;
+        if (!tool_round && !completed_round && !has_visible_text(resp.text)) {
+            response_free(&resp);
+            cJSON_DeleteItemFromArray(msgs, input_at);
+            return -1;
+        }
+
         cJSON_AddItemToArray(msgs, resp.msg); resp.msg = NULL;
+        completed_round = 1;
 
-        /* router signalled context pressure: seal in the background and keep going */
-        if (resp.compact && !compacting && cfg->compact_extra[0]) {
-            snapshot_len = cJSON_GetArraySize(msgs);
-            if (compact_fire(cfg, msgs, compact_res, sizeof(compact_res)) == 0)
-                compacting = 1;
-        }
-
-        if (!strcmp(resp.finish_reason, "stop")) {
-            if (resp.text) { printf("%s\n", resp.text); log_write(log, "ASST", resp.text); }
-            response_free(&resp); return 0;   /* msg already transferred; frees finish_reason */
-        }
-        if (!strcmp(resp.finish_reason, "tool_calls") && resp.tool_calls) {
+        if (tool_round) {
             process_tool_calls(resp.tool_calls, msgs, log);
-            response_free(&resp); continue;
+        } else if (resp.text) {
+            printf("%s\n", resp.text); log_write(log, "ASST", resp.text);
         }
-        if (resp.text) { printf("%s\n", resp.text); log_write(log, "ASST", resp.text); }
-        response_free(&resp); return 0;
+        int compact = resp.compact;
+        response_free(&resp);
+        if (compact) compact_messages(cfg, msgs, sealed, log);
+        if (!tool_round) return 0;
     }
+    if (!completed_round) cJSON_DeleteItemFromArray(msgs, input_at);
     fprintf(stderr, "error: max turns (%d) reached\n", cfg->max_turns);
     return -1;
 }
 
-/* Read one turn from f, terminated by `delim`. Grows as needed (replaces an
-   fgets()+4KB buffer that silently truncated long pasted prompts). Returns NULL
-   at EOF with no bytes read.
-
-   The delimiter frames turns *without* touching their content: a human at a tty
-   uses '\n' (one typed line = one turn); a driving program (non-tty stdin) uses
-   '\0', which a turn — being text — can never contain, so a multi-line message
-   survives verbatim as a single turn instead of fanning out into one turn (and
-   one LLM call) per line. No escaping, no reinterpretation of backslashes. */
 static char *read_turn(FILE *f, int delim) {
     size_t cap = 65536, len = 0;
     char *buf = malloc(cap);
@@ -606,23 +809,20 @@ int main(int argc, char **argv) {
     if (!sysprompt) return 1;
 
     char sid[32] = {0};
-    { FILE *ur = fopen("/dev/urandom", "r");
-      if (ur) { unsigned char b[8];
-          if (fread(b, 1, 8, ur) == 8)
-              snprintf(sid, sizeof(sid), "%02x%02x%02x%02x%02x%02x%02x%02x",
-                  b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]);
-          fclose(ur); }
-      if (!sid[0]) snprintf(sid, sizeof(sid), "%lx%x", (long)time(NULL), getpid()); }
+    make_session_id(sid);
     snprintf(cfg.session, MAX_VALUE, "%s", sid);  /* sent on every request for cache affinity */
     mkdirp(cfg.log_dir);
-    char lp[600]; snprintf(lp, sizeof(lp), "%s/%s.txt", cfg.log_dir, sid);
-    FILE *log = fopen(lp, "a");
-    if (log) { time_t now = time(NULL); fprintf(log, "=== %s %s", sid, ctime(&now)); fflush(log); }
+    char jp[600];
+    snprintf(jp, sizeof(jp), "%s/%s.jsonl", cfg.log_dir, sid);
+    LogSink log = {
+        .jsonl = open_private_append(jp),
+        .sequence = 0
+    };
 
     cJSON *msgs = cJSON_CreateArray();
     cJSON_AddItemToArray(msgs, make_msg("system", sysprompt));
     cJSON *tools = cJSON_Parse(TOOLS_JSON);
-    int rc = 0;
+    int rc = 0, sealed = 0;
     fprintf(stderr, "subzeroclaw · %s\n", sid);
 
     if (argc > 1) {
@@ -633,11 +833,8 @@ int main(int argc, char **argv) {
             memcpy(p, argv[i], l); p += l;
         }
         *p = '\0';
-        rc = agent_run(&cfg, msgs, tools, input, log);
+        rc = agent_run(&cfg, msgs, tools, input, &sealed, &log);
     } else {
-        /* A human at a tty ends a turn with Enter ('\n'); a driving program
-           (pipe/FIFO) ends each turn with a NUL byte, letting one turn carry
-           newlines verbatim instead of fanning out per line (see read_turn). */
         int delim = isatty(STDIN_FILENO) ? '\n' : '\0';
         for (;;) {
             printf("> "); fflush(stdout);
@@ -647,14 +844,14 @@ int main(int argc, char **argv) {
             if (!strcmp(input, "/quit") || !strcmp(input, "/exit")) {
                 free(input); break;
             }
-            agent_run(&cfg, msgs, tools, input, log);
+            agent_run(&cfg, msgs, tools, input, &sealed, &log);
             free(input);
             printf("\n<<TURN_COMPLETE>>\n");
             fflush(stdout);
         }
     }
     cJSON_Delete(msgs); cJSON_Delete(tools); free(sysprompt);
-    if (log) fclose(log);
+    if (log.jsonl) fclose(log.jsonl);
     return rc;
 }
 #endif

--- a/src/test.c
+++ b/src/test.c
@@ -13,7 +13,7 @@ static int tests_failed = 0;
 
 static void test_shell_echo(void) {
     TEST("shell: echo");
-    char *r = tool_execute("shell", "{\"command\": \"echo hello_subzeroclaw\"}");
+    char *r = tool_execute("shell", "echo hello_subzeroclaw");
     assert(r);
     if (strstr(r, "hello_subzeroclaw")) PASS();
     else FAIL(r);
@@ -22,7 +22,7 @@ static void test_shell_echo(void) {
 
 static void test_shell_pipe(void) {
     TEST("shell: pipe + grep");
-    char *r = tool_execute("shell", "{\"command\": \"echo abc123def | grep -o '[0-9]\\\\+'\"}");
+    char *r = tool_execute("shell", "echo abc123def | grep -o '[0-9]\\+'");
     assert(r);
     if (strstr(r, "123")) PASS();
     else FAIL(r);
@@ -31,7 +31,7 @@ static void test_shell_pipe(void) {
 
 static void test_shell_stderr(void) {
     TEST("shell: captures stderr");
-    char *r = tool_execute("shell", "{\"command\": \"LC_ALL=C ls /nonexistent_path_xyz\"}");
+    char *r = tool_execute("shell", "LC_ALL=C ls /nonexistent_path_xyz");
     assert(r);
     if (strstr(r, "No such file") || strstr(r, "cannot access") || strstr(r, "error")) PASS();
     else FAIL(r);
@@ -40,7 +40,7 @@ static void test_shell_stderr(void) {
 
 static void test_unknown_tool(void) {
     TEST("unknown tool returns error");
-    char *r = tool_execute("teleport", "{\"destination\": \"mars\"}");
+    char *r = tool_execute("teleport", "mars");
     assert(r);
     if (strstr(r, "unknown tool")) PASS();
     else FAIL(r);
@@ -48,8 +48,8 @@ static void test_unknown_tool(void) {
 }
 
 static void test_shell_bad_args(void) {
-    TEST("shell: bad args JSON");
-    char *r = tool_execute("shell", "not json at all");
+    TEST("shell: missing command");
+    char *r = tool_execute("shell", NULL);
     assert(r);
     if (strstr(r, "error")) PASS();
     else FAIL(r);
@@ -58,8 +58,7 @@ static void test_shell_bad_args(void) {
 
 static void test_shell_heredoc(void) {
     TEST("shell: heredoc not corrupted by wrap");
-    char *r = tool_execute("shell",
-        "{\"command\": \"cat <<'END'\\nhello_heredoc\\nEND\"}");
+    char *r = tool_execute("shell", "cat <<'END'\nhello_heredoc\nEND");
     assert(r);
     if (strstr(r, "hello_heredoc")) PASS();
     else FAIL(r);
@@ -68,7 +67,7 @@ static void test_shell_heredoc(void) {
 
 static void test_shell_exit_code_ok(void) {
     TEST("shell: exit code prefix on success");
-    char *r = tool_execute("shell", "{\"command\": \"true\"}");
+    char *r = tool_execute("shell", "true");
     assert(r);
     if (strstr(r, "[exit:0]") == r) PASS();
     else FAIL(r);
@@ -77,11 +76,92 @@ static void test_shell_exit_code_ok(void) {
 
 static void test_shell_exit_code_fail(void) {
     TEST("shell: exit code prefix on failure");
-    char *r = tool_execute("shell", "{\"command\": \"exit 42\"}");
+    char *r = tool_execute("shell", "exit 42");
     assert(r);
     if (strstr(r, "[exit:42]") == r) PASS();
     else FAIL(r);
     free(r);
+}
+
+static void test_shell_large_output_is_drained(void) {
+    TEST("shell: output beyond cap is drained without blocking");
+    char *r = tool_execute("shell",
+        "dd if=/dev/zero bs=1024 count=256 2>/dev/null | tr '\\000' x");
+    int ok = r && !strncmp(r, "[exit:0] ", 9) && strlen(r) < MAX_OUTPUT + 16;
+    if (ok) PASS(); else FAIL("large output did not finish within the bounded result");
+    free(r);
+}
+
+static void test_http_post_uses_anonymous_pipes(void) {
+    TEST("http_post: curl argv clean, config/body piped");
+    char dir[] = "/tmp/subzeroclaw-curl-XXXXXX";
+    char *made = mkdtemp(dir);
+    char curl_path[1024];
+    snprintf(curl_path, sizeof(curl_path), "%s/curl", made ? made : "");
+    FILE *script = made ? fopen(curl_path, "w") : NULL;
+    if (script) {
+        fputs("#!/bin/sh\n"
+              "case \"$*\" in *router.invalid/fail*) exit 22;; esac\n"
+              "printf 'ARGV:'\n"
+              "for arg do printf '[%s]' \"$arg\"; done\n"
+              "printf '\\nCONFIG:\\n'\n"
+              "prev=\nconfig=\n"
+              "for arg do\n"
+              "  if [ \"$prev\" = '--config' ]; then config=$arg; fi\n"
+              "  prev=$arg\n"
+              "done\n"
+              "cat \"$config\"\n"
+              "dd if=/dev/zero bs=1024 count=128 2>/dev/null | tr '\\000' x\n"
+              "printf 'BODY:\\n'\n"
+              "cat\n", script);
+        fclose(script);
+        chmod(curl_path, 0700);
+    }
+
+    const char *old_path_value = getenv("PATH");
+    char *old_path = old_path_value ? strdup(old_path_value) : NULL;
+    char path[4096];
+    snprintf(path, sizeof(path), "%s:%s", dir, old_path ? old_path : "");
+    if (script) setenv("PATH", path, 1);
+
+    const char *key = "test-secret-key";
+    const char *session = "test-session";
+    char *body = malloc(256 * 1024 + 1);
+    if (body) { memset(body, 'b', 256 * 1024); body[256 * 1024] = '\0'; }
+    char *response = script && body ? http_post("https://router.invalid/v1/compact",
+                                                key, session, body) : NULL;
+    char *argv_end = response ? strchr(response, '\n') : NULL;
+    size_t argv_len = argv_end ? (size_t)(argv_end - response) : 0;
+    char *argv = argv_end ? strndup(response, argv_len) : NULL;
+    const char *expected_config =
+        "CONFIG:\nheader = \"Authorization: Bearer test-secret-key\"\n"
+        "header = \"X-Unhardcoded-Session: test-session\"\n";
+    char *body_capture = response ? strstr(response, "BODY:\n") : NULL;
+    int captured = response && argv && argv_end &&
+        !strncmp(argv_end + 1, expected_config, strlen(expected_config)) &&
+        body_capture && !strcmp(body_capture + strlen("BODY:\n"), body);
+    int clean_argv = argv && body && strstr(argv, "[--fail]") &&
+        strstr(argv, "[-m][120]") && !strstr(argv, "--fail-with-body") &&
+        strstr(argv, "[--config][/dev/fd/") &&
+        strstr(argv, "[--data-binary][@-]") && !strstr(argv, key) &&
+        !strstr(argv, session) && !strstr(argv, body) &&
+        !strstr(argv, "Authorization") && !strstr(argv, "/tmp/");
+    char *bad_newline = script ? http_post("https://router.invalid", "bad\nkey",
+                                            session, body) : NULL;
+    char *bad_quote = script ? http_post("https://router.invalid", key,
+                                          "bad\"session", body) : NULL;
+    char *curl_failed = script ? http_post("https://router.invalid/fail", key,
+                                           session, body) : NULL;
+    int rejected = !bad_newline && !bad_quote && !curl_failed;
+
+    if (old_path) { setenv("PATH", old_path, 1); free(old_path); }
+    else unsetenv("PATH");
+    free(bad_newline); free(bad_quote); free(curl_failed);
+    free(argv); free(response); free(body);
+    if (script) unlink(curl_path);
+    if (made) rmdir(dir);
+    if (captured && clean_argv && rejected) PASS();
+    else FAIL("curl transport exposed data, changed flags, or failed capture");
 }
 
 /* ======== STDIN TURN FRAMING TESTS ======== */
@@ -125,7 +205,10 @@ static void test_turn_newline_framed_tty(void) {
 
 static void test_turn_eof_empty_is_null(void) {
     TEST("read_turn: EOF with no bytes returns NULL");
-    FILE *f = fmemopen("", 0, "r");
+    /* fmemopen(..., 0, ...) may legally return NULL (notably on macOS), while
+       an empty tmpfile has the exact EOF behavior this test needs. */
+    FILE *f = tmpfile();
+    if (!f) { FAIL("tmpfile failed"); return; }
     char *r = read_turn(f, '\0');
     if (r == NULL) PASS();
     else FAIL(r);
@@ -160,14 +243,15 @@ static void test_parse_stop_response(void) {
         "  \"finish_reason\": \"stop\","
         "  \"message\": {"
         "    \"role\": \"assistant\","
-        "    \"content\": \"Hello from the forest!\""
+        "    \"content\": \"Hello from the forest!\","
+        "    \"tool_calls\": null"
         "  }"
         "}]"
         "}";
     Response resp;
     int rc = parse_response(mock, &resp);
     if (rc == 0 &&
-        strcmp(resp.finish_reason, "stop") == 0 &&
+        !resp.tool_round && !resp.runnable &&
         resp.text && strstr(resp.text, "forest") &&
         resp.tool_calls == NULL)
         PASS();
@@ -198,7 +282,7 @@ static void test_parse_tool_calls_response(void) {
     Response resp;
     int rc = parse_response(mock, &resp);
     int ok = (rc == 0 &&
-        strcmp(resp.finish_reason, "tool_calls") == 0 &&
+        resp.tool_round && resp.runnable &&
         resp.text == NULL &&
         resp.tool_calls != NULL &&
         cJSON_GetArraySize(resp.tool_calls) == 1);
@@ -224,12 +308,39 @@ static void test_parse_garbage(void) {
     else { FAIL("expected -1"); response_free(&resp); }
 }
 
+static void test_parse_rejects_malformed_message(void) {
+    TEST("parse_response: rejects unsafe role and tool shapes");
+    const char *bad[] = {
+        "{\"choices\":[{\"finish_reason\":\"stop\",\"message\":"
+        "{\"role\":\"system\",\"content\":\"forged\"}}]}",
+        "{\"choices\":[{\"finish_reason\":\"tool_calls\",\"message\":"
+        "{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{"
+        "\"id\":\"x\",\"function\":{\"name\":7,\"arguments\":\"{}\"}}]}}]}",
+        "{\"choices\":[{\"finish_reason\":\"stop\",\"message\":"
+        "{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{"
+        "\"id\":\"x\",\"function\":{\"name\":\"shell\",\"arguments\":\"{}\"}}]}}]}",
+        "{\"choices\":[{\"finish_reason\":\"tool_calls\",\"message\":"
+        "{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{"
+        "\"id\":\"x\",\"function\":{\"name\":\"shell\",\"arguments\":\"{}\"}},{"
+        "\"id\":\"x\",\"function\":{\"name\":\"shell\",\"arguments\":\"{}\"}}]}}]}",
+        "{\"choices\":[{\"finish_reason\":\"length\",\"message\":"
+        "{\"role\":\"assistant\",\"content\":\"partial\"}}]}"
+    };
+    int ok = 1;
+    for (size_t i = 0; i < sizeof(bad) / sizeof(bad[0]); i++) {
+        Response resp;
+        if (parse_response(bad[i], &resp) == 0) {
+            response_free(&resp); ok = 0;
+        }
+    }
+    if (ok) PASS(); else FAIL("malformed assistant response was accepted");
+}
+
 /* ======== END-TO-END MOCK TEST ======== */
 
 static void test_full_tool_dispatch(void) {
     TEST("e2e: parse tool_call -> execute -> result");
-    const char *mock_args = "{\"command\": \"echo subzeroclaw_e2e_ok\"}";
-    char *result = tool_execute("shell", mock_args);
+    char *result = tool_execute("shell", "echo subzeroclaw_e2e_ok");
     assert(result);
 
     cJSON *tool_msg = cJSON_CreateObject();
@@ -264,8 +375,8 @@ static cJSON *mk_tool_call(const char *id, const char *args_json) {
     return tc;
 }
 
-static void test_round_has_command(void) {
-    TEST("round_has_command: real vs empty tool-call rounds");
+static void test_valid_tool_calls_marks_runnable(void) {
+    TEST("valid_tool_calls: validates first, marks runnable rounds");
     cJSON *valid = cJSON_CreateArray();
     cJSON_AddItemToArray(valid, mk_tool_call("c1", "{\"command\":\"echo hi\"}"));
     cJSON *empty = cJSON_CreateArray();
@@ -277,28 +388,25 @@ static void test_round_has_command(void) {
     cJSON *blank = cJSON_CreateArray();
     cJSON_AddItemToArray(blank, mk_tool_call("c1", "{\"command\":\"\"}"));   /* blank command string */
     cJSON *none = cJSON_CreateArray();
+    int v = 0, e = 0, m = 0, b = 0, n = 0;
     int ok =
-        round_has_command(valid) == 1 &&
-        round_has_command(empty) == 0 &&
-        round_has_command(mixed) == 1 &&
-        round_has_command(blank) == 0 &&
-        round_has_command(none)  == 0;
-    if (ok) PASS(); else FAIL("round_has_command mismatch");
+        valid_tool_calls(valid, &v) && v &&
+        valid_tool_calls(empty, &e) && !e &&
+        valid_tool_calls(mixed, &m) && !m &&
+        valid_tool_calls(blank, &b) && !b &&
+        valid_tool_calls(none, &n) && !n;
+    if (ok) PASS(); else FAIL("tool-call validation/runnable mismatch");
     cJSON_Delete(valid); cJSON_Delete(empty); cJSON_Delete(mixed);
     cJSON_Delete(blank); cJSON_Delete(none);
 }
 
-/* The kept path's integrity invariant (object §3): a round round_has_command lets
-   through (some call carries a command) is RECORDED, so process_tool_calls must
-   leave no orphan — every tool_call_id, the empty ones included, gets a matching
-   `tool` reply or the next request 400s. Asserted on a MIXED round, exactly the
-   shape the discard guard keeps. (round_has_command, the discard gate, is covered
-   above; here we pin the complementary record-and-pair half.) */
+/* A runnable multi-call round must pair every tool_call_id before the next
+   request. Semantically invalid mixed rounds are discarded by the preflight. */
 static void test_recorded_round_pairs_every_call(void) {
-    TEST("recorded mixed round: every tool_call_id paired (no orphan)");
+    TEST("recorded multi-call round: every tool_call_id paired (no orphan)");
     cJSON *tool_calls = cJSON_CreateArray();
-    cJSON_AddItemToArray(tool_calls, mk_tool_call("c1", ""));                          /* empty — kept because the round is mixed */
-    cJSON_AddItemToArray(tool_calls, mk_tool_call("c2", "{\"command\":\"echo ok\"}")); /* runnable */
+    cJSON_AddItemToArray(tool_calls, mk_tool_call("c1", "{\"command\":\"true\"}"));
+    cJSON_AddItemToArray(tool_calls, mk_tool_call("c2", "{\"command\":\"echo ok\"}"));
     cJSON *msgs = cJSON_CreateArray();
     process_tool_calls(tool_calls, msgs, NULL);
 
@@ -312,7 +420,7 @@ static void test_recorded_round_pairs_every_call(void) {
         if (tcid && cJSON_IsString(tcid) && !strcmp(tcid->valuestring, "c2")) seen_c2 = 1;
     }
     if (n == 2 && all_tool && seen_c1 && seen_c2) PASS();
-    else FAIL("orphaned tool_call_id (mixed round not fully paired)");
+    else FAIL("orphaned tool_call_id (multi-call round not fully paired)");
 
     cJSON_Delete(tool_calls);
     cJSON_Delete(msgs);
@@ -374,27 +482,36 @@ static void test_build_request(void) {
 }
 
 static void test_build_request_extra_merge(void) {
-    TEST("build_request: REQUEST_EXTRA merges, override wins");
+    TEST("build_request: REQUEST_EXTRA cannot replace runtime context");
     Config cfg; memset(&cfg, 0, sizeof(cfg));
+    snprintf(cfg.session, MAX_VALUE, "runtime-session");
     snprintf(cfg.request_extra, MAX_EXTRA,
-        "{\"temperature\": 0.5, \"model\": \"override-model\"}");
+        "{\"temperature\":0.5,\"model\":\"override-model\","
+        "\"session\":\"forged\",\"messages\":[],\"tools\":[],"
+        "\"Session\":\"forged-case\",\"MESSAGES\":[],\"Tools\":[]}");
     cJSON *msgs = cJSON_CreateArray();
     cJSON_AddItemToArray(msgs, make_msg("user", "hi"));
-    char *json = build_request(&cfg, msgs, NULL);
+    cJSON *tools = cJSON_Parse(TOOLS_JSON);
+    char *json = build_request(&cfg, msgs, tools);
     assert(json);
     cJSON *req = cJSON_Parse(json); assert(req);
     cJSON *temp  = cJSON_GetObjectItem(req, "temperature");
     cJSON *model = cJSON_GetObjectItem(req, "model");
+    cJSON *session = cJSON_GetObjectItem(req, "session");
     cJSON *m     = cJSON_GetObjectItem(req, "messages");
+    cJSON *t     = cJSON_GetObjectItem(req, "tools");
     int model_keys = 0; cJSON *c = NULL;
     cJSON_ArrayForEach(c, req) if (c->string && !strcmp(c->string, "model")) model_keys++;
     if (temp && cJSON_IsNumber(temp) && temp->valuedouble == 0.5 &&
-        model && !strcmp(model->valuestring, "override-model") &&  /* override wins */
-        model_keys == 1 &&                                          /* no duplicate */
-        m && cJSON_GetArraySize(m) == 1)
+        model && !strcmp(model->valuestring, "override-model") && model_keys == 1 &&
+        session && !strcmp(session->valuestring, "runtime-session") &&
+        !cJSON_GetObjectItemCaseSensitive(req, "Session") &&
+        !cJSON_GetObjectItemCaseSensitive(req, "MESSAGES") &&
+        !cJSON_GetObjectItemCaseSensitive(req, "Tools") &&
+        m && cJSON_GetArraySize(m) == 1 && t && cJSON_GetArraySize(t) == 1)
         PASS();
-    else FAIL("merge/override mismatch");
-    cJSON_Delete(req); free(json); cJSON_Delete(msgs);
+    else FAIL("request_extra replaced a runtime-owned field");
+    cJSON_Delete(req); free(json); cJSON_Delete(msgs); cJSON_Delete(tools);
 }
 
 static void test_build_request_extra_empty(void) {
@@ -422,6 +539,7 @@ static void test_build_request_extra_garbage(void) {
     else FAIL("garbage broke the request");
     if (req) cJSON_Delete(req); free(json); cJSON_Delete(msgs);
 }
+
 
 /* ======== CONFIG TESTS ======== */
 
@@ -461,6 +579,7 @@ static void test_config_scrubs_env(void) {
     setenv("SUBZEROCLAW_API_KEY", "sk-test-scrub", 1);
     setenv("SUBZEROCLAW_ENDPOINT", "https://test.example/v1/chat", 1);
     setenv("SUBZEROCLAW_REQUEST_EXTRA", "{\"temperature\":0}", 1);
+    setenv("SUBZEROCLAW_COMPACT_EXTRA", "{\"legacy_secret\":true}", 1);
     Config cfg;
     int rc = config_load(&cfg);
     if (old_home) { setenv("HOME", old_home, 1); free(old_home); }
@@ -475,7 +594,8 @@ static void test_config_scrubs_env(void) {
     int env_scrubbed =
         getenv("SUBZEROCLAW_API_KEY") == NULL &&
         getenv("SUBZEROCLAW_ENDPOINT") == NULL &&
-        getenv("SUBZEROCLAW_REQUEST_EXTRA") == NULL;
+        getenv("SUBZEROCLAW_REQUEST_EXTRA") == NULL &&
+        getenv("SUBZEROCLAW_COMPACT_EXTRA") == NULL;
 
     if (cfg_ok && env_scrubbed) PASS();
     else if (!cfg_ok) FAIL("cfg lost a provider value");
@@ -499,32 +619,542 @@ static void test_parse_compact_flag(void) {
     if (ok2) response_free(&r2);
 }
 
-static void test_compact_splice(void) {
-    TEST("compact_splice: append-only seal keeps post-snapshot turns");
+static cJSON *compaction_fixture(void) {
+    char old[900];
+    memset(old, 'x', sizeof(old) - 1); old[sizeof(old) - 1] = '\0';
     cJSON *msgs = cJSON_CreateArray();
-    cJSON_AddItemToArray(msgs, make_msg("system", "sys"));     /* 0 */
-    cJSON_AddItemToArray(msgs, make_msg("user", "u0"));        /* 1 */
-    cJSON_AddItemToArray(msgs, make_msg("assistant", "a0"));   /* 2 */
-    cJSON_AddItemToArray(msgs, make_msg("user", "u1"));        /* 3 */
-    cJSON_AddItemToArray(msgs, make_msg("assistant", "a1"));   /* 4  -> snapshot_len = 5 */
-    cJSON_AddItemToArray(msgs, make_msg("user", "u2"));        /* 5  arrived while sealing */
-    cJSON_AddItemToArray(msgs, make_msg("assistant", "a2"));   /* 6  */
-    char path[64];
-    write_temp("testcres",
-        "{\"messages\":[{\"role\":\"system\",\"content\":\"sys\"},"
-        "{\"role\":\"system\",\"content\":\"SEALED\"}],\"compacted\":true}",
-        path, sizeof(path));
-    compact_splice(msgs, 5, path, NULL);   /* consumes + unlinks path */
-    int n = cJSON_GetArraySize(msgs);
-    cJSON *m1 = cJSON_GetArrayItem(msgs, 1), *last = cJSON_GetArrayItem(msgs, n - 1);
-    cJSON *c1 = m1 ? cJSON_GetObjectItem(m1, "content") : NULL;
-    cJSON *cl = last ? cJSON_GetObjectItem(last, "content") : NULL;
-    if (n == 4 &&                                       /* sys + SEALED + u2 + a2 */
-        c1 && !strcmp(c1->valuestring, "SEALED") &&
-        cl && !strcmp(cl->valuestring, "a2"))           /* post-snapshot turns kept */
-        PASS();
-    else FAIL("splice result wrong");
+    cJSON_AddItemToArray(msgs, make_msg("system", "system"));
+    cJSON_AddItemToArray(msgs, make_msg("developer", "developer"));
+    for (int i = 0; i < 8; i++) {
+        cJSON_AddItemToArray(msgs, make_msg("user", old));
+        cJSON_AddItemToArray(msgs, make_msg("assistant", old));
+    }
+    return msgs;
+}
+
+static cJSON *compaction_response(const char *summary, int compacted) {
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "contract_version", 3);
+    cJSON_AddBoolToObject(root, "compacted", compacted);
+    cJSON_AddStringToObject(root, "reason", compacted ? "compacted" : "declined");
+    if (compacted && summary) cJSON_AddStringToObject(root, "summary", summary);
+    return root;
+}
+
+static int apply_root(cJSON *msgs, int *sealed, cJSON *root, LogSink *log) {
+    CompactLayout layout;
+    if (compact_layout(msgs, *sealed, &layout) != 1) return -1;
+    char *json = cJSON_PrintUnformatted(root);
+    int rc = json ? compact_apply_response(msgs, &layout, json, sealed, log) : -1;
+    free(json);
+    return rc;
+}
+
+static void test_compact_applies_local_canonical_array_and_logs(void) {
+    TEST("compact: local canonical splice + JSONL evidence");
+    cJSON *msgs = compaction_fixture();
+    cJSON *before = cJSON_Duplicate(msgs, 1);
+    size_t expected_before_bytes = json_size(msgs);
+    cJSON *root = compaction_response("SEALED", 1);
+    LogSink log = {.jsonl = tmpfile(), .sequence = 0};
+    int sealed = 0;
+    int rc = apply_root(msgs, &sealed, root, &log);
+    cJSON *boundary = cJSON_GetArrayItem(msgs, 2);
+    cJSON *summary = cJSON_GetArrayItem(msgs, 3);
+    int authority_ok =
+        cJSON_Compare(cJSON_GetArrayItem(msgs, 0), cJSON_GetArrayItem(before, 0), 1) &&
+        cJSON_Compare(cJSON_GetArrayItem(msgs, 1), cJSON_GetArrayItem(before, 1), 1);
+    char line1[4096] = {0}, line2[4096] = {0};
+    rewind(log.jsonl);
+    fgets(line1, sizeof(line1), log.jsonl);
+    fgets(line2, sizeof(line2), log.jsonl);
+    cJSON *e1 = cJSON_Parse(line1), *e2 = cJSON_Parse(line2);
+    cJSON *r1 = e1 ? cJSON_GetObjectItem(e1, "role") : NULL;
+    cJSON *r2 = e2 ? cJSON_GetObjectItem(e2, "role") : NULL;
+    cJSON *c1 = e1 ? cJSON_GetObjectItem(e1, "content") : NULL;
+    cJSON *c2 = e2 ? cJSON_GetObjectItem(e2, "content") : NULL;
+    cJSON *meta = c1 && cJSON_IsString(c1) ? cJSON_Parse(c1->valuestring) : NULL;
+    cJSON *event = meta ? cJSON_GetObjectItem(meta, "event") : NULL;
+    cJSON *before_bytes = meta ? cJSON_GetObjectItem(meta, "before_bytes") : NULL;
+    cJSON *after_bytes = meta ? cJSON_GetObjectItem(meta, "after_bytes") : NULL;
+    size_t expected_after_bytes = json_size(msgs);
+    int ok = rc == 1 && sealed && cJSON_GetArraySize(msgs) == 16 && authority_ok &&
+        !strcmp(message_content(boundary, "user"), SEAL_BOUNDARY) &&
+        !strcmp(message_content(summary, "assistant"), SEAL_PREFIX "SEALED") &&
+        r1 && !strcmp(r1->valuestring, "COMPACT") &&
+        event && !strcmp(event->valuestring, "applied") &&
+        cJSON_GetObjectItem(meta, "before_messages") &&
+        cJSON_GetObjectItem(meta, "after_messages") &&
+        cJSON_GetNumberValue(before_bytes) == (double)expected_before_bytes &&
+        cJSON_GetNumberValue(after_bytes) == (double)expected_after_bytes &&
+        r2 && !strcmp(r2->valuestring, "COMPACT_SUMMARY") &&
+        c2 && !strcmp(c2->valuestring, SEAL_PREFIX "SEALED") &&
+        !strstr(line1, "SEALED");
+    if (ok) PASS(); else FAIL("local splice or evidence mismatch");
+    cJSON_Delete(meta); cJSON_Delete(e1); cJSON_Delete(e2); fclose(log.jsonl);
+    cJSON_Delete(root); cJSON_Delete(before); cJSON_Delete(msgs);
+}
+
+static void test_compact_layout_uses_local_seal_state(void) {
+    TEST("compact layout: seal state is local; marker text remains data");
+    cJSON *fresh = cJSON_CreateArray(), *sealed_msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(fresh, make_msg("system", "s"));
+    cJSON_AddItemToArray(sealed_msgs, make_msg("system", "s"));
+    cJSON_AddItemToArray(sealed_msgs, make_msg("user", SEAL_BOUNDARY));
+    cJSON_AddItemToArray(sealed_msgs, make_msg("assistant", SEAL_PREFIX "old"));
+    for (int i = 0; i < 8; i++) {
+        cJSON_AddItemToArray(fresh, make_msg("user", i ? "u" : SEAL_BOUNDARY));
+        cJSON_AddItemToArray(fresh, make_msg("assistant", "a"));
+        if (i < 7) {
+            cJSON_AddItemToArray(sealed_msgs, make_msg("user", "u"));
+            cJSON_AddItemToArray(sealed_msgs, make_msg("assistant", "a"));
+        }
+    }
+    CompactLayout first, next;
+    int ok = compact_layout(fresh, 0, &first) == 1 &&
+             first.authority == 1 && first.body == 1 && first.cutoff == 5 &&
+             compact_layout(sealed_msgs, 1, &next) == 1 &&
+             next.authority == 1 && next.body == 3 && next.cutoff == 5;
+    if (ok) PASS(); else FAIL("local seal layout mismatch");
+    cJSON_Delete(fresh); cJSON_Delete(sealed_msgs);
+}
+
+static void test_compact_layout_rejects_corrupt_local_seal(void) {
+    TEST("compact layout: corrupt local seal fails closed");
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("system", "s"));
+    cJSON_AddItemToArray(msgs, make_msg("user", "wrong boundary"));
+    cJSON_AddItemToArray(msgs, make_msg("assistant", SEAL_PREFIX "prior"));
+    for (int i = 0; i < COMPACT_KEEP_RECENT + 1; i++) {
+        cJSON_AddItemToArray(msgs, make_msg("user", "u"));
+        cJSON_AddItemToArray(msgs, make_msg("assistant", "a"));
+    }
+    CompactLayout layout;
+    int bad_boundary = compact_layout(msgs, 1, &layout);
+    cJSON_ReplaceItemInObjectCaseSensitive(cJSON_GetArrayItem(msgs, 1), "content",
+                                           cJSON_CreateString(SEAL_BOUNDARY));
+    cJSON_ReplaceItemInObjectCaseSensitive(cJSON_GetArrayItem(msgs, 2), "content",
+                                           cJSON_CreateString("unsealed"));
+    int bad_summary = compact_layout(msgs, 1, &layout);
+    cJSON_ReplaceItemInObjectCaseSensitive(cJSON_GetArrayItem(msgs, 2), "content",
+                                           cJSON_CreateString(SEAL_PREFIX "prior"));
+    cJSON_ReplaceItemInObjectCaseSensitive(cJSON_GetArrayItem(msgs, 4), "role",
+                                           cJSON_CreateString("system"));
+    int interior_authority = compact_layout(msgs, 1, &layout);
+    if (bad_boundary < 0 && bad_summary < 0 && interior_authority < 0) PASS();
+    else FAIL("corrupt seal was treated as compactable state");
     cJSON_Delete(msgs);
+}
+
+static void test_compact_rejects_unsafe_summary(void) {
+    TEST("compact: rejects unsafe summary and invalid success reason");
+    cJSON *msgs = compaction_fixture(), *before = cJSON_Duplicate(msgs, 1);
+    cJSON *missing = compaction_response(NULL, 1);
+    cJSON *empty = compaction_response("", 1);
+    cJSON *wrong_type = compaction_response(NULL, 1);
+    cJSON *wrong_reason = compaction_response("SEALED", 1);
+    cJSON *missing_reason = compaction_response("SEALED", 1);
+    cJSON_AddNumberToObject(wrong_type, "summary", 7);
+    cJSON_ReplaceItemInObject(wrong_reason, "reason", cJSON_CreateString("declined"));
+    cJSON_DeleteItemFromObject(missing_reason, "reason");
+    int sealed = 0;
+    int ok = apply_root(msgs, &sealed, missing, NULL) < 0 &&
+             apply_root(msgs, &sealed, empty, NULL) < 0 &&
+             apply_root(msgs, &sealed, wrong_type, NULL) < 0 &&
+             apply_root(msgs, &sealed, wrong_reason, NULL) < 0 &&
+             apply_root(msgs, &sealed, missing_reason, NULL) < 0 && !sealed &&
+             cJSON_Compare(msgs, before, 1);
+    if (ok) PASS(); else FAIL("unsafe summary changed context");
+    cJSON_Delete(missing); cJSON_Delete(empty); cJSON_Delete(wrong_type);
+    cJSON_Delete(wrong_reason); cJSON_Delete(missing_reason);
+    cJSON_Delete(before); cJSON_Delete(msgs);
+}
+
+static void test_compact_accepts_any_positive_reduction(void) {
+    TEST("compact: any positive local reduction is accepted");
+    cJSON *msgs = compaction_fixture();
+    size_t before = json_size(msgs);
+    char summary[3001];
+    memset(summary, 's', sizeof(summary) - 1); summary[sizeof(summary) - 1] = '\0';
+    cJSON *root = compaction_response(summary, 1);
+    int sealed = 0;
+    int rc = apply_root(msgs, &sealed, root, NULL);
+    size_t after = json_size(msgs);
+    int ok = rc == 1 && sealed && after < before &&
+             (before - after) * 100 < before * 5;
+    if (ok) PASS(); else FAIL("positive reduction was rejected or exceeded fixture target");
+    cJSON_Delete(root); cJSON_Delete(msgs);
+}
+
+static void test_compact_false_and_insufficient_reduction_are_noops(void) {
+    TEST("compact: declined/large summary are no-ops");
+    cJSON *msgs = compaction_fixture();
+    cJSON *before = cJSON_Duplicate(msgs, 1);
+    cJSON *declined = compaction_response(NULL, 0);
+    cJSON_ReplaceItemInObject(declined, "reason", cJSON_CreateString("REMOTE SECRET"));
+    LogSink log = {.jsonl = tmpfile(), .sequence = 0};
+    int sealed = 0;
+    int declined_rc = apply_root(msgs, &sealed, declined, &log);
+    char status[2048] = {0}, extra[8] = {0};
+    rewind(log.jsonl);
+    fgets(status, sizeof(status), log.jsonl);
+    int one_status = fgets(extra, sizeof(extra), log.jsonl) == NULL &&
+        strstr(status, "router_declined") && !strstr(status, "REMOTE SECRET");
+    char huge[7000];
+    memset(huge, 's', sizeof(huge) - 1);
+    huge[sizeof(huge) - 1] = '\0';
+    cJSON *large = compaction_response(huge, 1);
+    int large_rc = apply_root(msgs, &sealed, large, NULL);
+    if (declined_rc == 0 && large_rc == 0 && one_status &&
+        cJSON_Compare(msgs, before, 1)) PASS();
+    else FAIL("no-op response changed context");
+    fclose(log.jsonl); cJSON_Delete(large); cJSON_Delete(declined);
+    cJSON_Delete(before); cJSON_Delete(msgs);
+}
+
+static void test_compact_rejects_wrong_contract(void) {
+    TEST("compact: requires integer contract v3");
+    cJSON *msgs = compaction_fixture(), *before = cJSON_Duplicate(msgs, 1);
+    cJSON *root = compaction_response("SEALED", 1);
+    cJSON_ReplaceItemInObject(root, "contract_version", cJSON_CreateNumber(2));
+    int sealed = 0;
+    int wrong = apply_root(msgs, &sealed, root, NULL);
+    cJSON_ReplaceItemInObject(root, "contract_version", cJSON_CreateNumber(2.5));
+    int fractional = apply_root(msgs, &sealed, root, NULL);
+    if (wrong < 0 && fractional < 0 && cJSON_Compare(msgs, before, 1)) PASS();
+    else FAIL("non-v3 response changed context");
+    cJSON_Delete(root); cJSON_Delete(before); cJSON_Delete(msgs);
+}
+
+static void test_session_id_shape(void) {
+    TEST("session id: urandom/fallback shape");
+    char sid[32] = {0};
+    make_session_id(sid);
+    if (sid[0] && strlen(sid) < sizeof(sid)) PASS(); else FAIL("empty session id");
+}
+
+static void test_agent_run_compacts_at_completed_seam(void) {
+    TEST("agent_run: tool result, compact seam, empty terminal");
+    char dir[] = "/tmp/subzeroclaw-seam-XXXXXX";
+    char *made = mkdtemp(dir), curl_path[1024], marker_path[1024];
+    snprintf(curl_path, sizeof(curl_path), "%s/curl", made ? made : "");
+    snprintf(marker_path, sizeof(marker_path), "%s/chat-once", made ? made : "");
+    FILE *script = made ? fopen(curl_path, "w") : NULL;
+    if (script) {
+        fputs("#!/bin/sh\nurl=\nprev=\n"
+              "for arg do [ \"$prev\" = '--url' ] && url=$arg; prev=$arg; done\n"
+              "cat >/dev/null\n"
+              "case \"$url\" in */compact) printf '%s' \"$SZC_TEST_COMPACT_RESPONSE\";;"
+              " *) if [ -e \"$SZC_TEST_CHAT_MARKER\" ]; then"
+              " printf '%s' \"$SZC_TEST_CHAT_SECOND\"; else"
+              " : >\"$SZC_TEST_CHAT_MARKER\"; printf '%s' \"$SZC_TEST_CHAT_FIRST\"; fi;; esac\n",
+              script);
+        fclose(script); chmod(curl_path, 0700);
+    }
+
+    cJSON *msgs = cJSON_CreateArray();
+    char old[1024]; memset(old, 'x', sizeof(old) - 1); old[sizeof(old) - 1] = '\0';
+    cJSON_AddItemToArray(msgs, make_msg("system", "s"));
+    for (int i = 0; i < COMPACT_KEEP_RECENT; i++) {
+        cJSON_AddItemToArray(msgs, make_msg("user", old));
+        cJSON_AddItemToArray(msgs, make_msg("assistant", old));
+    }
+    cJSON *compact = cJSON_CreateObject();
+    cJSON_AddNumberToObject(compact, "contract_version", 3);
+    cJSON_AddBoolToObject(compact, "compacted", 1);
+    cJSON_AddStringToObject(compact, "reason", "compacted");
+    cJSON_AddStringToObject(compact, "summary", "SEALED");
+    char *compact_json = cJSON_PrintUnformatted(compact);
+    const char *chat_first =
+        "{\"choices\":[{\"finish_reason\":\"tool_calls\",\"message\":"
+        "{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{"
+        "\"id\":\"call-1\",\"type\":\"function\",\"function\":{"
+        "\"name\":\"shell\",\"arguments\":\"{\\\"command\\\":\\\"true\\\"}\"}}]}}],"
+        "\"x_router\":{\"compact\":true}}";
+    const char *chat_second =
+        "{\"choices\":[{\"finish_reason\":\"stop\",\"message\":"
+        "{\"role\":\"assistant\",\"content\":null}}]}";
+    if (script && compact_json) {
+        setenv("SZC_TEST_CHAT_FIRST", chat_first, 1);
+        setenv("SZC_TEST_CHAT_SECOND", chat_second, 1);
+        setenv("SZC_TEST_CHAT_MARKER", marker_path, 1);
+        setenv("SZC_TEST_COMPACT_RESPONSE", compact_json, 1);
+    }
+    const char *old_path_value = getenv("PATH");
+    char *old_path = old_path_value ? strdup(old_path_value) : NULL;
+    char path[4096]; snprintf(path, sizeof(path), "%s:%s", dir, old_path ? old_path : "");
+    if (script && compact_json) setenv("PATH", path, 1);
+
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    snprintf(cfg.api_key, MAX_VALUE, "test-key");
+    snprintf(cfg.endpoint, MAX_VALUE, "https://router.invalid/v1/chat/completions");
+    snprintf(cfg.session, MAX_VALUE, "seam-session");
+    cfg.max_turns = 2;
+    cJSON *tools = cJSON_Parse(TOOLS_JSON);
+    LogSink log = {.jsonl = tmpfile(), .sequence = 0};
+    int sealed = 0;
+    int rc = script && compact_json
+        ? agent_run(&cfg, msgs, tools, "latest", &sealed, &log) : -1;
+    char logged[8192] = {0};
+    if (log.jsonl) { rewind(log.jsonl); fread(logged, 1, sizeof(logged) - 1, log.jsonl); }
+    char *user = strstr(logged, "\"role\":\"USER\"");
+    char *tool = strstr(logged, "\"role\":\"TOOL\"");
+    char *result = strstr(logged, "\"role\":\"RES\"");
+    char *asst = strstr(logged, "\"role\":\"ASST\"");
+    char *event = strstr(logged, "\"role\":\"COMPACT\"");
+    char *summary = strstr(logged, "\"role\":\"COMPACT_SUMMARY\"");
+    int ok = rc == 0 && sealed && cJSON_GetArraySize(msgs) == 17 &&
+        !strcmp(message_content(cJSON_GetArrayItem(msgs, 1), "user"), SEAL_BOUNDARY) &&
+        !strcmp(message_content(cJSON_GetArrayItem(msgs, 2), "assistant"),
+                SEAL_PREFIX "SEALED") &&
+        !strcmp(message_role(cJSON_GetArrayItem(msgs, 3)), "user") &&
+        user && tool && result && !asst && event && summary &&
+        user < tool && tool < result && result < event && event < summary;
+
+    if (old_path) { setenv("PATH", old_path, 1); free(old_path); } else unsetenv("PATH");
+    unsetenv("SZC_TEST_CHAT_FIRST"); unsetenv("SZC_TEST_CHAT_SECOND");
+    unsetenv("SZC_TEST_CHAT_MARKER"); unsetenv("SZC_TEST_COMPACT_RESPONSE");
+    if (log.jsonl) fclose(log.jsonl);
+    cJSON_Delete(tools); cJSON_Delete(msgs); cJSON_Delete(compact); free(compact_json);
+    if (script) unlink(curl_path); if (made) { unlink(marker_path); rmdir(dir); }
+    if (ok) PASS();
+    else FAIL("complete tool round with empty terminal was not retained and compacted");
+}
+
+static void test_agent_run_rolls_back_unanswered_input(void) {
+    TEST("agent_run: unanswered input does not poison history");
+    cJSON *msgs = compaction_fixture();
+    cJSON *before = cJSON_Duplicate(msgs, 1);
+    cJSON *tools = cJSON_Parse(TOOLS_JSON);
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    snprintf(cfg.api_key, MAX_VALUE, "test-key");
+    snprintf(cfg.endpoint, MAX_VALUE, "https://router.invalid/v1/chat/completions");
+    snprintf(cfg.session, MAX_VALUE, "invalid\"session");
+    cfg.max_turns = 1;
+    int sealed = 0;
+    int rc = agent_run(&cfg, msgs, tools, "unanswered", &sealed, NULL);
+    CompactLayout layout;
+    int ok = rc < 0 && cJSON_Compare(msgs, before, 1) &&
+             compact_layout(msgs, sealed, &layout) == 1;
+    if (ok) PASS(); else FAIL("failed input remained in compactable history");
+    cJSON_Delete(tools); cJSON_Delete(before); cJSON_Delete(msgs);
+}
+
+static void test_agent_run_preflights_every_tool_before_side_effects(void) {
+    TEST("agent_run: malformed later tool blocks every side effect");
+    char dir[] = "/tmp/subzeroclaw-preflight-XXXXXX", curl_path[1024], marker[1024];
+    char *made = mkdtemp(dir);
+    snprintf(curl_path, sizeof(curl_path), "%s/curl", made ? made : "");
+    snprintf(marker, sizeof(marker), "%s/should-not-exist", made ? made : "");
+    FILE *script = made ? fopen(curl_path, "w") : NULL;
+    if (script) {
+        fputs("#!/bin/sh\ncat >/dev/null\nprintf '%s' \"$SZC_TEST_CHAT_RESPONSE\"\n",
+              script);
+        fclose(script); chmod(curl_path, 0700);
+    }
+
+    char response[4096];
+    snprintf(response, sizeof(response),
+        "{\"choices\":[{\"finish_reason\":\"tool_calls\",\"message\":{"
+        "\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{"
+        "\"id\":\"valid-first\",\"function\":{\"name\":\"shell\","
+        "\"arguments\":\"{\\\"command\\\":\\\"touch %s\\\"}\"}},{"
+        "\"id\":\"invalid-second\",\"function\":{\"name\":\"shell\","
+        "\"arguments\":\"{\\\"command\\\":\\\"true\\\"}TRAIL\"}}]}}]}", marker);
+    setenv("SZC_TEST_CHAT_RESPONSE", response, 1);
+    const char *old_path_value = getenv("PATH");
+    char *old_path = old_path_value ? strdup(old_path_value) : NULL;
+    char path[4096]; snprintf(path, sizeof(path), "%s:%s", dir, old_path ? old_path : "");
+    if (script) setenv("PATH", path, 1);
+
+    Config cfg; memset(&cfg, 0, sizeof(cfg));
+    snprintf(cfg.api_key, MAX_VALUE, "test-key");
+    snprintf(cfg.endpoint, MAX_VALUE, "https://router.invalid/v1/chat/completions");
+    cfg.max_turns = 1;
+    cJSON *msgs = cJSON_CreateArray(), *tools = cJSON_Parse(TOOLS_JSON);
+    cJSON_AddItemToArray(msgs, make_msg("system", "s"));
+    int sealed = 0;
+    int rc = script ? agent_run(&cfg, msgs, tools, "request", &sealed, NULL) : 0;
+    int ok = rc < 0 && access(marker, F_OK) != 0 && cJSON_GetArraySize(msgs) == 1;
+
+    if (old_path) { setenv("PATH", old_path, 1); free(old_path); } else unsetenv("PATH");
+    unsetenv("SZC_TEST_CHAT_RESPONSE");
+    cJSON_Delete(tools); cJSON_Delete(msgs);
+    if (script) unlink(curl_path); if (made) { unlink(marker); rmdir(dir); }
+    if (ok) PASS(); else FAIL("a tool ran before the full round was validated");
+}
+
+static void test_agent_run_rolls_back_empty_terminal(void) {
+    TEST("agent_run: empty terminal response does not answer input");
+    char dir[] = "/tmp/subzeroclaw-empty-XXXXXX", curl_path[1024];
+    char *made = mkdtemp(dir);
+    snprintf(curl_path, sizeof(curl_path), "%s/curl", made ? made : "");
+    FILE *script = made ? fopen(curl_path, "w") : NULL;
+    if (script) {
+        fputs("#!/bin/sh\ncat >/dev/null\nprintf '%s' \"$SZC_TEST_CHAT_RESPONSE\"\n",
+              script);
+        fclose(script); chmod(curl_path, 0700);
+    }
+    const char *old_path_value = getenv("PATH");
+    char *old_path = old_path_value ? strdup(old_path_value) : NULL;
+    char path[4096];
+    snprintf(path, sizeof(path), "%s:%s", dir, old_path ? old_path : "");
+    if (script) setenv("PATH", path, 1);
+
+    const char *responses[] = {
+        "{\"choices\":[{\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":null}}]}",
+        "{\"choices\":[{\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"\"}}]}",
+        "{\"choices\":[{\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\" \\n\\t\"}}]}"
+    };
+    int ok = script != NULL;
+    for (size_t i = 0; ok && i < sizeof(responses) / sizeof(responses[0]); i++) {
+        cJSON *msgs = compaction_fixture(), *before = cJSON_Duplicate(msgs, 1);
+        cJSON *tools = cJSON_Parse(TOOLS_JSON);
+        Config cfg; memset(&cfg, 0, sizeof(cfg));
+        snprintf(cfg.api_key, MAX_VALUE, "test-key");
+        snprintf(cfg.endpoint, MAX_VALUE, "https://router.invalid/v1/chat/completions");
+        snprintf(cfg.session, MAX_VALUE, "empty-session");
+        cfg.max_turns = 1;
+        int sealed = 0;
+        setenv("SZC_TEST_CHAT_RESPONSE", responses[i], 1);
+        int rc = agent_run(&cfg, msgs, tools, "unanswered", &sealed, NULL);
+        ok = rc < 0 && cJSON_Compare(msgs, before, 1);
+        cJSON_Delete(tools); cJSON_Delete(before); cJSON_Delete(msgs);
+    }
+
+    if (old_path) { setenv("PATH", old_path, 1); free(old_path); } else unsetenv("PATH");
+    unsetenv("SZC_TEST_CHAT_RESPONSE");
+    if (script) unlink(curl_path); if (made) rmdir(dir);
+    if (ok) PASS(); else FAIL("empty terminal response remained in history");
+}
+
+static void test_second_compaction_merges_previous_summary(void) {
+    TEST("compact: second pass replaces prior semantic memory");
+    cJSON *msgs = compaction_fixture();
+    int sealed = 0;
+    cJSON *first = compaction_response("FIRST", 1);
+    int first_rc = apply_root(msgs, &sealed, first, NULL);
+    for (int i = 0; i < 2; i++) {
+        cJSON_AddItemToArray(msgs, make_msg("user", "new user"));
+        cJSON_AddItemToArray(msgs, make_msg("assistant", "new answer"));
+    }
+    CompactLayout layout;
+    char *body = compact_layout(msgs, sealed, &layout) == 1
+        ? compact_request_body(msgs, sealed, &layout) : NULL;
+    cJSON *request = body ? cJSON_Parse(body) : NULL;
+    cJSON *previous = request ? cJSON_GetObjectItem(request, "previous_summary") : NULL;
+    cJSON *second = compaction_response("MERGED", 1);
+    int second_rc = apply_root(msgs, &sealed, second, NULL);
+    const char *summary = message_content(cJSON_GetArrayItem(msgs, 3), "assistant");
+    int ok = first_rc == 1 && second_rc == 1 && previous &&
+             !strcmp(previous->valuestring, "FIRST") && summary &&
+             !strcmp(summary, SEAL_PREFIX "MERGED");
+    if (ok) PASS(); else FAIL("prior summary was not merged and replaced");
+    cJSON_Delete(second); cJSON_Delete(request); free(body);
+    cJSON_Delete(first); cJSON_Delete(msgs);
+}
+
+static void test_compact_request_sends_only_raw_prior_and_aged_history(void) {
+    TEST("compact request: raw prior + aged only; authority/boundary/tail stay local");
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("system", "authority"));
+    cJSON_AddItemToArray(msgs, make_msg("user", SEAL_BOUNDARY));
+    cJSON_AddItemToArray(msgs, make_msg("assistant", SEAL_PREFIX "prior"));
+    for (int i = 0; i < COMPACT_KEEP_RECENT + 1; i++) {
+        cJSON_AddItemToArray(msgs, make_msg("user", i ? "recent" : "aged"));
+        cJSON_AddItemToArray(msgs, make_msg("assistant", i ? "new answer" : "old answer"));
+    }
+    CompactLayout layout;
+    int ready = compact_layout(msgs, 1, &layout) == 1;
+    char *body = ready ? compact_request_body(msgs, 1, &layout) : NULL;
+    cJSON *req = body ? cJSON_Parse(body) : NULL;
+    cJSON *aged = req ? cJSON_GetObjectItem(req, "messages") : NULL;
+    cJSON *previous = req ? cJSON_GetObjectItem(req, "previous_summary") : NULL;
+    int ok = cJSON_GetNumberValue(cJSON_GetObjectItem(req, "contract_version")) == 3 &&
+             cJSON_IsString(previous) && !strcmp(previous->valuestring, "prior") &&
+             cJSON_IsArray(aged) && cJSON_GetArraySize(aged) == 2 &&
+             !strcmp(message_content(cJSON_GetArrayItem(aged, 0), "user"), "aged") &&
+             !strcmp(message_content(cJSON_GetArrayItem(aged, 1), "assistant"), "old answer") &&
+             !cJSON_GetObjectItem(req, "max_tokens") &&
+             !cJSON_GetObjectItem(req, "keep_recent_interactions");
+    if (ok) PASS(); else FAIL("non-aged context leaked into compact request");
+    cJSON_Delete(req); free(body); cJSON_Delete(msgs);
+}
+
+static void test_compact_request_keeps_aged_tool_group_intact(void) {
+    TEST("compact request: aged tool group stays intact");
+    cJSON *msgs = cJSON_CreateArray();
+    cJSON_AddItemToArray(msgs, make_msg("system", "authority"));
+    cJSON_AddItemToArray(msgs, make_msg("user", "aged question"));
+    cJSON_AddItemToArray(msgs, cJSON_Parse(
+        "{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{"
+        "\"id\":\"aged-call\",\"type\":\"function\",\"function\":{"
+        "\"name\":\"shell\",\"arguments\":\"{\\\"command\\\":\\\"true\\\"}\"}}]}"));
+    cJSON_AddItemToArray(msgs, cJSON_Parse(
+        "{\"role\":\"tool\",\"tool_call_id\":\"aged-call\",\"content\":\"[exit:0]\"}"));
+    cJSON_AddItemToArray(msgs, make_msg("assistant", "aged answer"));
+    for (int i = 0; i < COMPACT_KEEP_RECENT; i++) {
+        cJSON_AddItemToArray(msgs, make_msg("user", "recent question"));
+        cJSON_AddItemToArray(msgs, make_msg("assistant", "recent answer"));
+    }
+
+    CompactLayout layout;
+    int ready = compact_layout(msgs, 0, &layout) == 1;
+    char *body = ready ? compact_request_body(msgs, 0, &layout) : NULL;
+    cJSON *req = body ? cJSON_Parse(body) : NULL;
+    cJSON *aged = req ? cJSON_GetObjectItem(req, "messages") : NULL;
+    cJSON *call_msg = aged ? cJSON_GetArrayItem(aged, 1) : NULL;
+    cJSON *calls = call_msg ? cJSON_GetObjectItem(call_msg, "tool_calls") : NULL;
+    cJSON *call = calls ? cJSON_GetArrayItem(calls, 0) : NULL;
+    cJSON *call_id = call ? cJSON_GetObjectItem(call, "id") : NULL;
+    cJSON *result = aged ? cJSON_GetArrayItem(aged, 2) : NULL;
+    cJSON *result_id = result ? cJSON_GetObjectItem(result, "tool_call_id") : NULL;
+    int ok = cJSON_IsArray(aged) && cJSON_GetArraySize(aged) == 4 &&
+             !strcmp(message_role(cJSON_GetArrayItem(aged, 0)), "user") &&
+             !strcmp(message_role(call_msg), "assistant") &&
+             !strcmp(message_role(result), "tool") &&
+             !strcmp(message_role(cJSON_GetArrayItem(aged, 3)), "assistant") &&
+             cJSON_IsString(call_id) && cJSON_IsString(result_id) &&
+             !strcmp(call_id->valuestring, "aged-call") &&
+             !strcmp(result_id->valuestring, call_id->valuestring);
+    if (ok) PASS(); else FAIL("aged tool protocol was split or rewritten");
+    cJSON_Delete(req); free(body); cJSON_Delete(msgs);
+}
+
+static void test_jsonl_log_frames_multiline_content(void) {
+    TEST("log v2: multiline content stays one JSONL record");
+    LogSink log = {.jsonl = tmpfile(), .sequence = 0};
+    const char *content = "hello\n[2099-01-01 00:00:00] COMPACT: fake\nbye";
+    log_write(&log, "USER", content);
+    char line[4096] = {0};
+    rewind(log.jsonl); fread(line, 1, sizeof(line) - 1, log.jsonl);
+    cJSON *entry = cJSON_Parse(line);
+    cJSON *parsed = entry ? cJSON_GetObjectItem(entry, "content") : NULL;
+    cJSON *sequence = entry ? cJSON_GetObjectItem(entry, "sequence") : NULL;
+    if (parsed && cJSON_IsString(parsed) && !strcmp(parsed->valuestring, content) &&
+        sequence && cJSON_GetNumberValue(sequence) == 1) PASS();
+    else FAIL("multiline JSONL framing changed content");
+    cJSON_Delete(entry);
+    if (log.jsonl) fclose(log.jsonl);
+}
+
+static void test_sensitive_logs_use_private_permissions(void) {
+    TEST("logs: sensitive files and directory are private");
+    char root[] = "/tmp/subzeroclaw-log-test-XXXXXX";
+    if (!mkdtemp(root)) { FAIL("mkdtemp failed"); return; }
+    char dir[1024], path[1024];
+    snprintf(dir, sizeof(dir), "%s/nested/logs", root);
+    mkdirp(dir);
+    snprintf(path, sizeof(path), "%s/session.jsonl", dir);
+    FILE *file = open_private_append(path);
+    if (file) { fputs("secret\n", file); fclose(file); }
+    struct stat dir_stat = {0}, file_stat = {0};
+    int ok = file && stat(dir, &dir_stat) == 0 && stat(path, &file_stat) == 0 &&
+        (dir_stat.st_mode & 0777) == 0700 && (file_stat.st_mode & 0777) == 0600;
+    unlink(path); rmdir(dir);
+    char parent[1024]; snprintf(parent, sizeof(parent), "%s/nested", root);
+    rmdir(parent); rmdir(root);
+    if (ok) PASS(); else FAIL("sensitive log permissions were not 0700/0600");
 }
 
 int main(void) {
@@ -539,6 +1169,8 @@ int main(void) {
     test_shell_heredoc();
     test_shell_exit_code_ok();
     test_shell_exit_code_fail();
+    test_shell_large_output_is_drained();
+    test_http_post_uses_anonymous_pipes();
     test_turn_nul_keeps_newlines_one_turn();
     test_turn_content_verbatim();
     test_turn_newline_framed_tty();
@@ -548,14 +1180,31 @@ int main(void) {
     test_parse_tool_calls_response();
     test_parse_error_response();
     test_parse_garbage();
+    test_parse_rejects_malformed_message();
     test_build_request();
     test_build_request_extra_merge();
     test_build_request_extra_empty();
     test_build_request_extra_garbage();
     test_parse_compact_flag();
-    test_compact_splice();
+    test_compact_applies_local_canonical_array_and_logs();
+    test_compact_layout_uses_local_seal_state();
+    test_compact_layout_rejects_corrupt_local_seal();
+    test_compact_rejects_unsafe_summary();
+    test_compact_accepts_any_positive_reduction();
+    test_compact_false_and_insufficient_reduction_are_noops();
+    test_compact_rejects_wrong_contract();
+    test_compact_request_sends_only_raw_prior_and_aged_history();
+    test_compact_request_keeps_aged_tool_group_intact();
+    test_jsonl_log_frames_multiline_content();
+    test_sensitive_logs_use_private_permissions();
+    test_session_id_shape();
+    test_agent_run_compacts_at_completed_seam();
+    test_agent_run_rolls_back_unanswered_input();
+    test_agent_run_preflights_every_tool_before_side_effects();
+    test_agent_run_rolls_back_empty_terminal();
+    test_second_compaction_merges_previous_summary();
     test_full_tool_dispatch();
-    test_round_has_command();
+    test_valid_tool_calls_marks_runnable();
     test_recorded_round_pairs_every_call();
     test_system_prompt();
     test_skills_loading();


### PR DESCRIPTION
## What changed

- Replaces the async v1 compaction lifecycle with a synchronous summary-only contract v3 call between complete protocol rounds.
- Keeps system/developer authority, the canonical boundary, prior seal, and six recent interaction groups local; only raw prior memory plus newly aged complete groups are sent to the router.
- Rebuilds the boundary and summary locally, requires a strict byte reduction, and applies the replacement in place only after every allocation succeeds.
- Emits one private framed JSONL stream. Bounded `COMPACT` evidence is separate from the sensitive exact `COMPACT_SUMMARY` applied to context.
- Moves credentials and request bodies through anonymous pipes instead of argv or temporary files.
- Preflights every tool call structurally and semantically before any command runs, requires fully consumed argument JSON, and drains oversized tool output while retaining a bounded result.
- Adds a CI workflow that builds the production binary and runs tests with both system and vendored cJSON.

## Why

The prior proposal doubled the runtime by introducing worker lifecycle, snapshots, staleness, fingerprints, cancellation, and merge states. Synchronous compaction removes those states by construction. The resulting runtime is 857 lines versus 660 on `main` (+197), down from the 1,366-line async proposal. The remaining delta owns only client-side context integrity, secret transport, and private structured evidence.

## Validation

- Production build + 50/50 tests with system cJSON.
- Production build + 50/50 tests with vendored cJSON.
- ASan + UBSan: 50/50, no sanitizer findings; only vendored cJSON's existing deprecated-`sprintf` compiler warnings.
- Regression coverage for large-output draining, all-call/no-side-effect preflight, trailing JSON garbage, exact byte metadata, corrupt authority, second compaction, and HTTP failure.
- Real HTTP E2E against the v3 FastAPI endpoint, followed by parser/dashboard verification of the private JSONL evidence.

