### PR TITLE
fix: guard unchecked malloc/realloc NULL dereferences

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -179,6 +179,7 @@ char *tool_execute(const char *name, const char *args_json) {
        The "; }" form breaks both. */
     size_t len = strlen(cmd);
     char *full = malloc(len + 16);
+    if (!full) { if (args) cJSON_Delete(args); return strdup("[exit:-1] error: out of memory"); }
     memcpy(full, "{\n", 2); memcpy(full + 2, cmd, len);
     memcpy(full + 2 + len, "\n} 2>&1", 8);
     if (args) cJSON_Delete(args);
@@ -186,6 +187,7 @@ char *tool_execute(const char *name, const char *args_json) {
     if (!fp) return strdup("[exit:-1] error: popen failed");
     /* Reserve 16 bytes at the head for the "[exit:N] " prefix */
     char *out = malloc(MAX_OUTPUT + 16);
+    if (!out) return strdup("[exit:-1] error: out of memory");
     size_t total = 16, n;
     /* Bound each read by the space left in `out` (cap = MAX_OUTPUT+16, with
        out[total] reserved for the trailing NUL). The previous loop kept the
@@ -211,6 +213,7 @@ char *tool_execute(const char *name, const char *args_json) {
 char *agent_build_system_prompt(const char *skills_dir) {
     size_t cap = 8192;
     char *prompt = malloc(cap);
+    if (!prompt) return NULL;
     size_t len = snprintf(prompt, cap,
         "You are SubZeroClaw, a minimal agentic assistant.\n"
         "You have one tool: shell. Use it to run any command.\n"
@@ -223,10 +226,17 @@ char *agent_build_system_prompt(const char *skills_dir) {
         char fp[MAX_PATH]; snprintf(fp, MAX_PATH, "%s/%s", skills_dir, entry->d_name);
         FILE *sf = fopen(fp, "r"); if (!sf) continue;
         fseek(sf, 0, SEEK_END); long sz = ftell(sf); fseek(sf, 0, SEEK_SET);
+        if (sz < 0) { fclose(sf); continue; }
         char *content = malloc(sz + 1);
+        if (!content) { fclose(sf); continue; }
         content[fread(content, 1, sz, sf)] = '\0'; fclose(sf);
         size_t clen = strlen(content);
-        while (len + clen + 128 >= cap) { cap *= 2; prompt = realloc(prompt, cap); }
+        while (len + clen + 128 >= cap) {
+            cap *= 2;
+            char *np = realloc(prompt, cap);
+            if (!np) { free(content); free(prompt); closedir(d); return NULL; }
+            prompt = np;
+        }
         len += snprintf(prompt + len, cap - len, "\n--- SKILL: %s ---\n", entry->d_name);
         memcpy(prompt + len, content, clen); len += clen; prompt[len] = '\0';
         free(content);
@@ -445,8 +455,10 @@ static void compact_splice(cJSON *msgs, int snapshot_len, const char *res_path, 
     cJSON *sp = root ? cJSON_GetObjectItem(root, "messages") : NULL;
     if (sp && cJSON_IsArray(sp) && cJSON_GetArraySize(msgs) >= snapshot_len) {
         for (int i = 0; i < snapshot_len; i++) cJSON_DeleteItemFromArray(msgs, 0);
-        for (int i = cJSON_GetArraySize(sp) - 1; i >= 0; i--)
-            cJSON_InsertItemInArray(msgs, 0, cJSON_Duplicate(cJSON_GetArrayItem(sp, i), 1));
+        for (int i = cJSON_GetArraySize(sp) - 1; i >= 0; i--) {
+            cJSON *dup = cJSON_Duplicate(cJSON_GetArrayItem(sp, i), 1);
+            if (dup) cJSON_InsertItemInArray(msgs, 0, dup);
+        }
         log_write(log, "SYS", "context compacted (append-only, async)");
     }
     if (root) cJSON_Delete(root);
@@ -575,6 +587,7 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
    survives verbatim as a single turn instead of fanning out into one turn (and
    one LLM call) per line. No escaping, no reinterpretation of backslashes. */
 static char *read_turn(FILE *f, int delim) {
+    if (!f) return NULL;
     size_t cap = 65536, len = 0;
     char *buf = malloc(cap);
     if (!buf) return NULL;

--- a/src/test.c
+++ b/src/test.c
@@ -125,6 +125,10 @@ static void test_turn_newline_framed_tty(void) {
 
 static void test_turn_eof_empty_is_null(void) {
     TEST("read_turn: EOF with no bytes returns NULL");
+    /* fmemopen("", 0, "r") returns NULL on some platforms (e.g. macOS);
+     * read_turn(NULL) must return NULL without crashing, and on platforms
+     * where fmemopen succeeds with a zero-length buffer, the immediate EOF
+     * (no bytes read) must also yield NULL. */
     FILE *f = fmemopen("", 0, "r");
     char *r = read_turn(f, '\0');
     if (r == NULL) PASS();
@@ -316,6 +320,31 @@ static void test_recorded_round_pairs_every_call(void) {
 
     cJSON_Delete(tool_calls);
     cJSON_Delete(msgs);
+}
+
+/* ======== NULL-SAFETY / OOM REGRESSION TESTS ======== */
+
+/* read_turn(NULL, ...) must return NULL without dereferencing the stream
+ * pointer.  Several callers feed it a FILE* that may be NULL when an upstream
+ * open fails (e.g. fmemopen("", 0, "r") returns NULL on macOS), so the guard
+ * prevents a segfault that previously killed the whole test suite. */
+static void test_read_turn_null_stream(void) {
+    TEST("read_turn: NULL stream returns NULL");
+    char *r = read_turn(NULL, '\0');
+    if (r == NULL) PASS();
+    else { FAIL("expected NULL"); free(r); }
+}
+
+/* agent_build_system_prompt against a nonexistent dir still returns a valid
+ * (non-NULL) prompt — the malloc at the top is now NULL-checked, so an OOM
+ * there yields NULL and the caller in main() already handles that.  Here we
+ * just confirm the happy path returns a usable prompt. */
+static void test_system_prompt_null_on_oom_path(void) {
+    TEST("agent_build_system_prompt: missing dir -> non-NULL prompt");
+    char *p = agent_build_system_prompt("/nonexistent_dir_xyz");
+    if (p && strstr(p, "SubZeroClaw")) PASS();
+    else FAIL(p ? "missing base prompt" : "(null)");
+    free(p);
 }
 
 /* ======== SYSTEM PROMPT / SKILLS TEST ======== */
@@ -543,6 +572,7 @@ int main(void) {
     test_turn_content_verbatim();
     test_turn_newline_framed_tty();
     test_turn_eof_empty_is_null();
+    test_read_turn_null_stream();
     test_tools_definitions();
     test_parse_stop_response();
     test_parse_tool_calls_response();
@@ -558,6 +588,7 @@ int main(void) {
     test_round_has_command();
     test_recorded_round_pairs_every_call();
     test_system_prompt();
+    test_system_prompt_null_on_oom_path();
     test_skills_loading();
     test_config_no_key();
     test_config_defaults();


### PR DESCRIPTION
## Summary

Several allocation sites dereferenced the returned pointer without a NULL check, causing a **segfault (SIGSEGV)** under memory pressure or when an upstream `open` fails. The sibling functions `read_turn`/`read_file`/`http_post` already NULL-check their allocations; these sites were inconsistent.

## Bugs fixed

### `tool_execute` — 2 unchecked `malloc` (HIGH)
- `malloc(len + 16)` for the command wrapper: on failure, `memcpy(full, "{\n", 2)` writes to NULL → SIGSEGV. Now frees `args` and returns an error string.
- `malloc(MAX_OUTPUT + 16)` for the output buffer: on failure, `fread(out + total, ...)` writes to `NULL + 16` → SIGSEGV. Now returns an error string.

### `agent_build_system_prompt` — 3 unchecked allocations (HIGH)
- Initial `malloc(cap)`: `snprintf(prompt, cap, ...)` dereferences NULL. Now returns NULL — the caller in `main()` already handles this (`if (!sysprompt) return 1`).
- `malloc(sz + 1)` for skill file content: `fread(content, ...)` writes to NULL. Now skips the file. Also guards `ftell < 0`.
- `realloc` in the growth loop: `prompt = realloc(prompt, cap)` overwrites `prompt` with NULL on failure, **leaking the old allocation**, then the next `snprintf`/`memcpy` crashes. Now frees `content`+`prompt`, closes the dir, returns NULL.

### `compact_splice` — unchecked `cJSON_Duplicate` (MEDIUM)
`cJSON_Duplicate` may return NULL under memory pressure. `cJSON_InsertItemInArray` silently rejects NULL items, but the result was not captured — relying on internal behavior. Now captures the result and skips NULL explicitly.

### `read_turn` — NULL `FILE*` dereference (MEDIUM)
`read_turn` called `fgetc(f)` without checking `f`. When a caller passes a NULL `FILE*` (e.g. `fmemopen("", 0, "r")` returns NULL on macOS), this segfaults. Now returns NULL early. **This was actively breaking the test suite on macOS** — `make test` segfaulted before any fix.

## Test changes

- Clarified the comment on `test_turn_eof_empty_is_null` explaining the macOS `fmemopen` behavior.
- Added `test_read_turn_null_stream` — regression guard for `read_turn(NULL, ...)`.
- Added `test_system_prompt_null_on_oom_path` — confirms the happy path still returns a valid prompt.

## Verification

```
$ make test
  SubZeroClaw test suite
  ═══════════════════════════════════════════

  ... (all tests) ...

  read_turn: NULL stream returns NULL           ✓
  agent_build_system_prompt: missing dir -> non-NULL prompt  ✓

  ═══════════════════════════════════════════
  33 passed, 0 failed
```

Before this PR, `make test` **segfaulted** on macOS (the `fmemopen("", 0, "r")` → NULL → `fgetc(NULL)` path). After this PR, all 33 tests pass.

The main binary (`make`) compiles cleanly with `-Wall -Wextra` and no new warnings.

## Checklist
- [x] Fixes are minimal and match the surrounding code style
- [x] No new compiler warnings
- [x] All existing tests pass
- [x] New regression tests added for the NULL-safety guards
- [x] The `read_turn` fix also repairs a pre-existing test-suite segfault on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when memory allocation fails while executing commands, building prompts, or loading skill content.
  * Added safer handling for invalid or unavailable input streams.
  * Prevented crashes during context compaction and skill-file loading failures.

* **Tests**
  * Added regression coverage for null stream handling and memory-related prompt-building scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->