### PR TITLE
fix: execute tool calls across finish-reason aliases

### DIFF
--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -247,6 +247,14 @@ static void response_free(Response *r) {
     if (r->msg) cJSON_Delete(r->msg);
 }
 
+/* Providers do not agree on the finish-reason spelling for a structured tool
+   turn (for example, OpenAI-compatible routers may emit "tool_calls" or
+   "tool_use"). The structured message is authoritative. */
+static int response_has_tool_calls(const Response *r) {
+    return r && r->tool_calls && cJSON_IsArray(r->tool_calls) &&
+           cJSON_GetArraySize(r->tool_calls) > 0;
+}
+
 /* references avoid copying the full message array */
 static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
     cJSON *req = cJSON_CreateObject();
@@ -524,6 +532,7 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
         if (parse_response(rb, &resp) != 0) { free(rb); return -1; }
         free(rb);
         if (resp.usage[0]) log_write(log, "USAGE", resp.usage);
+        int has_tool_calls = response_has_tool_calls(&resp);
 
         /* Discard a tool-call round with no runnable command instead of recording it,
            so the model can't few-shot off its own malformed call and spiral (codex
@@ -535,8 +544,7 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
            MIXED round (at least one call carries a command) is recorded instead,
            and process_tool_calls then pairs every id with a `tool` reply, the empty
            calls included (asserted by test_recorded_round_pairs_every_call). */
-        if (!strcmp(resp.finish_reason, "tool_calls") && resp.tool_calls &&
-            !round_has_command(resp.tool_calls)) {
+        if (has_tool_calls && !round_has_command(resp.tool_calls)) {
             response_free(&resp);   /* discard: the empty call never enters history */
             continue;
         }
@@ -550,13 +558,15 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
                 compacting = 1;
         }
 
+        /* Execute the structured call regardless of provider-specific
+           finish_reason aliases. It must take precedence over terminal reasons. */
+        if (has_tool_calls) {
+            process_tool_calls(resp.tool_calls, msgs, log);
+            response_free(&resp); continue;
+        }
         if (!strcmp(resp.finish_reason, "stop")) {
             if (resp.text) { printf("%s\n", resp.text); log_write(log, "ASST", resp.text); }
             response_free(&resp); return 0;   /* msg already transferred; frees finish_reason */
-        }
-        if (!strcmp(resp.finish_reason, "tool_calls") && resp.tool_calls) {
-            process_tool_calls(resp.tool_calls, msgs, log);
-            response_free(&resp); continue;
         }
         if (resp.text) { printf("%s\n", resp.text); log_write(log, "ASST", resp.text); }
         response_free(&resp); return 0;

--- a/src/test.c
+++ b/src/test.c
@@ -207,6 +207,35 @@ static void test_parse_tool_calls_response(void) {
     response_free(&resp);
 }
 
+static void test_parse_tool_use_response(void) {
+    TEST("parse_response: tool_use alias");
+    const char *mock = "{"
+        "\"choices\": [{"
+        "  \"finish_reason\": \"tool_use\","
+        "  \"message\": {"
+        "    \"role\": \"assistant\","
+        "    \"content\": null,"
+        "    \"tool_calls\": [{"
+        "      \"id\": \"call_alias\","
+        "      \"type\": \"function\","
+        "      \"function\": {"
+        "        \"name\": \"shell\","
+        "        \"arguments\": \"{\\\"command\\\": \\\"echo alias\\\"}\""
+        "      }"
+        "    }]"
+        "  }"
+        "}]"
+        "}";
+    Response resp;
+    int rc = parse_response(mock, &resp);
+    int ok = (rc == 0 &&
+        strcmp(resp.finish_reason, "tool_use") == 0 &&
+        response_has_tool_calls(&resp));
+    if (ok) PASS();
+    else FAIL("tool_use alias was not recognized as a tool-call turn");
+    response_free(&resp);
+}
+
 static void test_parse_error_response(void) {
     TEST("parse_response: API error");
     const char *mock = "{\"error\": {\"message\": \"rate limited\"}}";
@@ -546,6 +575,7 @@ int main(void) {
     test_tools_definitions();
     test_parse_stop_response();
     test_parse_tool_calls_response();
+    test_parse_tool_use_response();
     test_parse_error_response();
     test_parse_garbage();
     test_build_request();


### PR DESCRIPTION
## Summary
- treat a non-empty structured `message.tool_calls` array as authoritative
- execute calls when providers return aliases such as `finish_reason: tool_use`
- preserve malformed/empty tool-call round protection

## Production failure
The GenMochi router returned a valid shell/reply tool call with `finish_reason: tool_use`. The runtime only handled the literal `tool_calls`, so it recorded an empty assistant turn and sent no Telegram reply.

## Tests
- `make test` (32 passed, 0 failed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of structured tool calls across providers, including responses labeled `tool_use`.
  - Tool calls are now prioritized correctly even when a response also includes a terminal reason.
  - Malformed tool-call responses continue to be rejected safely.

- **Tests**
  - Added coverage for parsing and detecting tool calls in `tool_use` responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->