### PR TITLE
Preserve session compaction and own HTTP subprocess cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: runtime tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y libcjson-dev curl
+      - run: make test test-integration

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ test: src/test.c src/subzeroclaw.c $(VENDOR)
 	$(CC) $(CFLAGS) -o test_subzeroclaw src/test.c $(VENDOR) $(LDFLAGS)
 	./test_subzeroclaw
 
+# Real executable, loopback-only provider; no credentials or model spend.
+test-integration: $(TARGET)
+	python3 -m unittest discover -s test -p 'test_*.py' -v
+
 clean:
 	rm -f $(TARGET) test_subzeroclaw
 
@@ -28,4 +32,4 @@ install: $(TARGET)
 	mkdir -p $(HOME)/.local/bin
 	cp $(TARGET) $(HOME)/.local/bin/
 
-.PHONY: clean install test
+.PHONY: clean install test test-integration

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **WARNING: This software executes arbitrary shell commands with no safety checks, no confirmation prompts, no sandboxing, and no guardrails. The LLM decides what to run and the runtime runs it — `rm -rf /` included. There is nothing between the model's output and your system. If you don't understand what that means, do not use this. This is a bare agentic loop: execute the task, whatever it takes, nothing more, nothing less.**
 
-**~550 lines of C. 55KB binary. A skill-driven agentic daemon for edge hardware.**
+**A single-file C runtime for skill-driven agents.**
 
 ```
 skill.md + LLM + shell + loop = autonomous agent
@@ -72,8 +72,11 @@ SubZeroClaw points its `endpoint` at [**unhardcoded**](https://github.com/genlay
   flag on the response), SubZeroClaw fires an append-only seal at the router's
   `/v1/compact` **in the background** and keeps taking turns; when the sealed block
   lands it splices it in *ahead* of the turns that arrived meanwhile. Compaction is
-  asynchronous — no turn is ever blocked, the prompt-cache prefix is never
-  rewritten, and you never see a pause. The seal routing + how many recent turns to
+  asynchronous: at most one seal is pending per session, including across user
+  turns. Snapshots include complete tool-call/result pairs. Failed requests or
+  empty responses retain history and permit a later retry. Normal EOF cancels
+  pending work and removes its private temporary files; abrupt process kills do
+  not guarantee cleanup. The seal routing + how many recent turns to
   keep verbatim ride in `SUBZEROCLAW_COMPACT_EXTRA` (the second JSON), e.g.
   `{"keep_recent":8,"policy_ir":[ "policy", … cheap summariser … ]}`.
 
@@ -130,8 +133,9 @@ The skills included in this repo (`skills/`) are just examples to show the forma
 ## Build
 
 ```bash
-make            # builds subzeroclaw (55KB)
-make test       # runs the test suite
+make            # builds subzeroclaw
+make test       # unit tests
+make test-integration  # executable + loopback provider; requires Python 3, no live LLM
 make install    # copies to ~/.local/bin/
 ```
 
@@ -250,7 +254,7 @@ Every session gets a random hex ID. All input, output, tool calls, and results a
 
 ```
 src/
-├── subzeroclaw.c   ~550 lines  The entire runtime
+├── subzeroclaw.c              The entire runtime
 ├── test.c                      the test suite
 ├── cJSON.c                     Vendored JSON parser
 └── cJSON.h
@@ -266,7 +270,7 @@ Every layer of "framework" between the model and the shell is complexity that ad
 
 OpenClaw solved the agentic loop with 430,000 lines of TypeScript. ZeroClaw re-solved it with 15,000 lines of Rust. Both are good — but both carry the weight of problems that only exist at platform scale: multi-tenancy, channel routing, identity portability, plugin registries.
 
-SubZeroClaw asks: what if the problem is just "one agent, one skill, one device"? Then the answer is ~550 readable lines of C.
+SubZeroClaw asks: what if the problem is just "one agent, one skill, one device"?
 
 ## License
 

--- a/src/subzeroclaw.c
+++ b/src/subzeroclaw.c
@@ -7,6 +7,9 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <signal.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <dirent.h>
 #include <cjson/cJSON.h>
 
@@ -114,40 +117,57 @@ static void log_write(FILE *log, const char *role, const char *content) {
     fprintf(log, "[%s] %s: %s\n", ts, role, content); fflush(log);
 }
 
-static int write_temp(const char *prefix, const char *data, char *out, size_t out_size) {
-    snprintf(out, out_size, "/tmp/.szc_%s_XXXXXX", prefix);
-    int fd = mkstemp(out); if (fd < 0) return -1;
-    FILE *f = fdopen(fd, "w");
-    if (!f) { close(fd); unlink(out); return -1; }
-    fputs(data, f); fclose(f);
-    return 0;
-}
-
 static char *http_post(const char *url, const char *api_key, const char *session,
-                       const char *body) {
-    char body_path[64], hdr_path[64];
-    if (write_temp("body", body, body_path, sizeof(body_path)) < 0) return NULL;
+                       const char *body, const char *work_dir) {
+    /* A compaction's parent owns its directory and can clean it on cancellation.
+       Ordinary requests own their own private directory. No config enters a shell. */
+    char own_dir[] = "/tmp/.szc_http_XXXXXX";
+    if (strpbrk(api_key, "\r\n") || (session && strpbrk(session, "\r\n"))) return NULL;
+    if (!work_dir) { if (!mkdtemp(own_dir)) return NULL; work_dir = own_dir; }
+    char body_path[128], hdr_path[128], body_arg[130], hdr_arg[130];
+    snprintf(body_path, sizeof(body_path), "%s/body", work_dir);
+    snprintf(hdr_path, sizeof(hdr_path), "%s/headers", work_dir);
+    char *buf = NULL;
     char hdr[2 * MAX_VALUE + 128];
     /* The unhardcoded router pins cache affinity AND meters per-session
        (GET /v1/session/{sid}: calls/tokens/cost) by the HEADER — the body
        "session" field alone is not honored by the deployed router. */
     if (session && session[0])
         snprintf(hdr, sizeof(hdr),
-                 "-H \"Authorization: Bearer %s\"\n-H \"X-Unhardcoded-Session: %s\"",
+                 "Authorization: Bearer %s\nX-Unhardcoded-Session: %s\n",
                  api_key, session);
     else
-        snprintf(hdr, sizeof(hdr), "-H \"Authorization: Bearer %s\"", api_key);
-    if (write_temp("hdr", hdr, hdr_path, sizeof(hdr_path)) < 0) { unlink(body_path); return NULL; }
-
-    char cmd[2048];
-    snprintf(cmd, sizeof(cmd),
-        "curl -s -m 120 -K '%s' -H 'Content-Type: application/json' -d @'%s' '%s' 2>&1",
-        hdr_path, body_path, url);
-    FILE *fp = popen(cmd, "r");
-    if (!fp) { unlink(body_path); unlink(hdr_path); return NULL; }
+        snprintf(hdr, sizeof(hdr), "Authorization: Bearer %s\n", api_key);
+    const char *paths[] = {body_path, hdr_path}, *data[] = {body, hdr};
+    for (int i = 0; i < 2; i++) {
+        int fd = open(paths[i], O_WRONLY | O_CREAT | O_EXCL, 0600);
+        if (fd < 0) goto cleanup;
+        FILE *f = fdopen(fd, "w");
+        if (!f) { close(fd); goto cleanup; }
+        int ok = fputs(data[i], f) >= 0;
+        if (fclose(f)) ok = 0;
+        if (!ok) goto cleanup;
+    }
+    snprintf(body_arg, sizeof(body_arg), "@%s", body_path);
+    snprintf(hdr_arg, sizeof(hdr_arg), "@%s", hdr_path);
+    int output[2];
+    if (pipe(output)) goto cleanup;
+    fflush(NULL);
+    pid_t pid = fork();
+    if (pid == 0) {
+        close(output[0]); dup2(output[1], STDOUT_FILENO); close(output[1]);
+        execlp("curl", "curl", "--silent", "--fail", "--max-time", "120",
+               "--header", hdr_arg, "--header", "Content-Type: application/json",
+               "--data-binary", body_arg, "--url", url, (char *)NULL);
+        _exit(127);
+    }
+    close(output[1]);
+    if (pid < 0) { close(output[0]); goto cleanup; }
+    FILE *fp = fdopen(output[0], "r");
+    if (!fp) { close(output[0]); kill(pid, SIGTERM); }
 
     size_t cap = 65536, len = 0, n;
-    char *buf = malloc(cap);
+    if (fp) buf = malloc(cap);
     while (buf && (n = fread(buf + len, 1, cap - len - 1, fp)) > 0) {
         len += n;
         if (len + 1 >= cap) {
@@ -158,7 +178,14 @@ static char *http_post(const char *url, const char *api_key, const char *session
         }
     }
     if (buf) buf[len] = '\0';
-    pclose(fp); unlink(body_path); unlink(hdr_path);
+    if (fp) fclose(fp);
+    int status = 0;
+    pid_t waited;
+    do { waited = waitpid(pid, &status, 0); } while (waited < 0 && errno == EINTR);
+    if (waited < 0 || !WIFEXITED(status) || WEXITSTATUS(status)) { free(buf); buf = NULL; }
+cleanup:
+    unlink(body_path); unlink(hdr_path);
+    if (work_dir == own_dir) rmdir(own_dir);
     return buf;
 }
 
@@ -247,6 +274,10 @@ static void response_free(Response *r) {
     if (r->msg) cJSON_Delete(r->msg);
 }
 
+static int response_has_tool_calls(const Response *r) {
+    return r && cJSON_IsArray(r->tool_calls) && cJSON_GetArraySize(r->tool_calls) > 0;
+}
+
 /* references avoid copying the full message array */
 static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
     cJSON *req = cJSON_CreateObject();
@@ -286,8 +317,8 @@ static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
         cJSON_AddItemReferenceToObject(req, "tools", tools); tools_ref = 1;
     }
     char *json = cJSON_PrintUnformatted(req);
-    if (msgs_ref)  cJSON_DetachItemFromObject(req, "messages");
-    if (tools_ref) cJSON_DetachItemFromObject(req, "tools");
+    if (msgs_ref)  cJSON_Delete(cJSON_DetachItemFromObject(req, "messages"));
+    if (tools_ref) cJSON_Delete(cJSON_DetachItemFromObject(req, "tools"));
     cJSON_Delete(req);
     return json;
 }
@@ -302,7 +333,7 @@ static char *build_request(const Config *cfg, cJSON *msgs, cJSON *tools) {
 SZC_WEAK char *llm_chat(const Config *cfg, cJSON *msgs, cJSON *tools) {
     char *rj = build_request(cfg, msgs, tools);
     if (!rj) return NULL;
-    char *rb = http_post(cfg->endpoint, cfg->api_key, cfg->session, rj);
+    char *rb = http_post(cfg->endpoint, cfg->api_key, cfg->session, rj, NULL);
     free(rj);
     return rb;
 }
@@ -385,11 +416,28 @@ static void compact_url(const Config *cfg, char *out, size_t sz) {
     else   snprintf(out, sz, "%s/compact", e);
 }
 
-/* Fire an append-only seal of the current `msgs` in the BACKGROUND: POST to the
-   router's /v1/compact, atomically writing the spliced array to `res_path`. The
-   seal routing + keep_recent ride in SUBZEROCLAW_COMPACT_EXTRA. Returns 0 if
-   launched; the agent keeps looping and picks up the result on a later turn. */
-static int compact_fire(const Config *cfg, cJSON *msgs, char *res_path, size_t res_sz) {
+/* One pending seal belongs to the session, not to an individual user turn.
+   The parent reads its private result only after reaping the child, so no
+   shell background job, rename protocol, or separate HTTP path is needed. */
+typedef struct {
+    pid_t pid;
+    int snapshot_len;
+    char dir[80], result_path[96];
+} Compaction;
+
+static void compact_clear(Compaction *pending) {
+    if (pending->result_path[0]) unlink(pending->result_path);
+    if (pending->dir[0]) {
+        char path[128];
+        snprintf(path, sizeof(path), "%s/body", pending->dir); unlink(path);
+        snprintf(path, sizeof(path), "%s/headers", pending->dir); unlink(path);
+        rmdir(pending->dir);
+    }
+    memset(pending, 0, sizeof(*pending));
+}
+
+static int compact_fire(const Config *cfg, cJSON *msgs, Compaction *pending) {
+    if (pending->pid) return -1;
     cJSON *req = cJSON_CreateObject();
     if (cfg->compact_extra[0]) {            /* keep_recent / policy_ir / max_tokens */
         cJSON *extra = cJSON_Parse(cfg->compact_extra);
@@ -404,34 +452,31 @@ static int compact_fire(const Config *cfg, cJSON *msgs, char *res_path, size_t r
     }
     cJSON_AddItemReferenceToObject(req, "messages", msgs);
     char *body = cJSON_PrintUnformatted(req);
-    cJSON_DetachItemFromObject(req, "messages");
+    cJSON_Delete(cJSON_DetachItemFromObject(req, "messages"));
     cJSON_Delete(req);
     if (!body) return -1;
 
-    char body_path[64], hdr_path[64];
-    if (write_temp("cbody", body, body_path, sizeof(body_path)) < 0) { free(body); return -1; }
+    snprintf(pending->dir, sizeof(pending->dir), "/tmp/.szc_compact_XXXXXX");
+    if (!mkdtemp(pending->dir)) { free(body); compact_clear(pending); return -1; }
+    snprintf(pending->result_path, sizeof(pending->result_path), "%s/result", pending->dir);
+    pending->snapshot_len = cJSON_GetArraySize(msgs);
+    fflush(NULL);
+    pid_t pid = fork();
+    if (pid == 0) {
+        setpgid(0, 0);
+        char url[MAX_VALUE + 16]; compact_url(cfg, url, sizeof(url));
+        char *reply = http_post(url, cfg->api_key, cfg->session, body, pending->dir);
+        FILE *f = reply ? fopen(pending->result_path, "w") : NULL;
+        int ok = 0;
+        if (f) { ok = fputs(reply, f) >= 0; if (fclose(f)) ok = 0; }
+        free(reply); free(body);
+        _exit(ok ? 0 : 1);
+    }
     free(body);
-    char hdr[2 * MAX_VALUE + 128];
-    /* same session header as the chat path: the seal call must meter (and
-       cache-pin) under the SAME sid as the conversation it seals */
-    if (cfg->session[0])
-        snprintf(hdr, sizeof(hdr),
-                 "-H \"Authorization: Bearer %s\"\n-H \"X-Unhardcoded-Session: %s\"",
-                 cfg->api_key, cfg->session);
-    else
-        snprintf(hdr, sizeof(hdr), "-H \"Authorization: Bearer %s\"", cfg->api_key);
-    if (write_temp("chdr", hdr, hdr_path, sizeof(hdr_path)) < 0) { unlink(body_path); return -1; }
-
-    char url[MAX_VALUE + 16]; compact_url(cfg, url, sizeof(url));
-    snprintf(res_path, res_sz, "/tmp/.szc_cres_%d", (int)getpid());
-    /* atomic: write .tmp then rename, so res_path appears only when complete; the
-       subshell cleans its own temp files and detaches (&) so this returns at once. */
-    char cmd[2048 + MAX_VALUE];
-    snprintf(cmd, sizeof(cmd),
-        "( curl -s -m 120 -K '%s' -H 'Content-Type: application/json' -d @'%s' '%s' "
-        "-o '%s.tmp' && mv '%s.tmp' '%s' ; rm -f '%s' '%s' ) >/dev/null 2>&1 &",
-        hdr_path, body_path, url, res_path, res_path, res_path, body_path, hdr_path);
-    return system(cmd) == 0 ? 0 : -1;
+    if (pid < 0) { compact_clear(pending); return -1; }
+    setpgid(pid, pid);
+    pending->pid = pid;
+    return 0;
 }
 
 /* A background seal finished: replace the `snapshot_len` compacted messages with
@@ -443,13 +488,34 @@ static void compact_splice(cJSON *msgs, int snapshot_len, const char *res_path, 
     if (!buf) return;
     cJSON *root = cJSON_Parse(buf); free(buf);
     cJSON *sp = root ? cJSON_GetObjectItem(root, "messages") : NULL;
-    if (sp && cJSON_IsArray(sp) && cJSON_GetArraySize(msgs) >= snapshot_len) {
+    if (sp && cJSON_IsArray(sp) && cJSON_GetArraySize(sp) > 0 &&
+        cJSON_GetArraySize(msgs) >= snapshot_len) {
         for (int i = 0; i < snapshot_len; i++) cJSON_DeleteItemFromArray(msgs, 0);
         for (int i = cJSON_GetArraySize(sp) - 1; i >= 0; i--)
             cJSON_InsertItemInArray(msgs, 0, cJSON_Duplicate(cJSON_GetArrayItem(sp, i), 1));
         log_write(log, "SYS", "context compacted (append-only, async)");
-    }
+    } else log_write(log, "SYS", "invalid compaction response; history retained");
     if (root) cJSON_Delete(root);
+}
+
+static void compact_poll(Compaction *pending, cJSON *msgs, FILE *log) {
+    if (!pending->pid) return;
+    int status;
+    pid_t done = waitpid(pending->pid, &status, WNOHANG);
+    if (!done || (done < 0 && errno == EINTR)) return;
+    if (done > 0 && WIFEXITED(status) && WEXITSTATUS(status) == 0)
+        compact_splice(msgs, pending->snapshot_len, pending->result_path, log);
+    else
+        log_write(log, "SYS", "context compaction failed; history retained");
+    compact_clear(pending);
+}
+
+static void compact_stop(Compaction *pending) {
+    if (pending->pid) {
+        kill(-pending->pid, SIGTERM);
+        while (waitpid(pending->pid, NULL, 0) < 0 && errno == EINTR) {}
+    }
+    compact_clear(pending);
 }
 
 static void process_tool_calls(cJSON *tool_calls, cJSON *msgs, FILE *log) {
@@ -503,20 +569,15 @@ static int round_has_command(cJSON *tool_calls) {
 }
 
 static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
-                     const char *input, FILE *log)
+                     const char *input, FILE *log, Compaction *pending)
 {
     cJSON_AddItemToArray(msgs, make_msg("user", input));
     log_write(log, "USER", input);
 
-    int compacting = 0, snapshot_len = 0;
-    char compact_res[80] = {0};
     for (int turn = 1; turn <= cfg->max_turns; turn++) {
         /* a background seal finished while we kept working? splice it in now —
            append-only, so it never collides with the turns added meanwhile. */
-        if (compacting && access(compact_res, F_OK) == 0) {
-            compact_splice(msgs, snapshot_len, compact_res, log);
-            compacting = 0;
-        }
+        compact_poll(pending, msgs, log);
         fprintf(stderr, "[%d] ...\n", turn);
         char *rb = llm_chat(cfg, msgs, tools);
         if (!rb) return -1;
@@ -524,6 +585,7 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
         if (parse_response(rb, &resp) != 0) { free(rb); return -1; }
         free(rb);
         if (resp.usage[0]) log_write(log, "USAGE", resp.usage);
+        int has_tool_calls = response_has_tool_calls(&resp);
 
         /* Discard a tool-call round with no runnable command instead of recording it,
            so the model can't few-shot off its own malformed call and spiral (codex
@@ -535,27 +597,20 @@ static int agent_run(const Config *cfg, cJSON *msgs, cJSON *tools,
            MIXED round (at least one call carries a command) is recorded instead,
            and process_tool_calls then pairs every id with a `tool` reply, the empty
            calls included (asserted by test_recorded_round_pairs_every_call). */
-        if (!strcmp(resp.finish_reason, "tool_calls") && resp.tool_calls &&
-            !round_has_command(resp.tool_calls)) {
+        if (has_tool_calls && !round_has_command(resp.tool_calls)) {
             response_free(&resp);   /* discard: the empty call never enters history */
             continue;
         }
 
         cJSON_AddItemToArray(msgs, resp.msg); resp.msg = NULL;
 
-        /* router signalled context pressure: seal in the background and keep going */
-        if (resp.compact && !compacting && cfg->compact_extra[0]) {
-            snapshot_len = cJSON_GetArraySize(msgs);
-            if (compact_fire(cfg, msgs, compact_res, sizeof(compact_res)) == 0)
-                compacting = 1;
-        }
+        /* Complete tool-call pairs before taking a compaction snapshot. */
+        if (has_tool_calls) process_tool_calls(resp.tool_calls, msgs, log);
 
-        if (!strcmp(resp.finish_reason, "stop")) {
-            if (resp.text) { printf("%s\n", resp.text); log_write(log, "ASST", resp.text); }
-            response_free(&resp); return 0;   /* msg already transferred; frees finish_reason */
-        }
-        if (!strcmp(resp.finish_reason, "tool_calls") && resp.tool_calls) {
-            process_tool_calls(resp.tool_calls, msgs, log);
+        if (resp.compact && !pending->pid && cfg->compact_extra[0])
+            compact_fire(cfg, msgs, pending);
+
+        if (has_tool_calls) {
             response_free(&resp); continue;
         }
         if (resp.text) { printf("%s\n", resp.text); log_write(log, "ASST", resp.text); }
@@ -622,6 +677,7 @@ int main(int argc, char **argv) {
     cJSON *msgs = cJSON_CreateArray();
     cJSON_AddItemToArray(msgs, make_msg("system", sysprompt));
     cJSON *tools = cJSON_Parse(TOOLS_JSON);
+    Compaction pending = {0};
     int rc = 0;
     fprintf(stderr, "subzeroclaw · %s\n", sid);
 
@@ -633,7 +689,7 @@ int main(int argc, char **argv) {
             memcpy(p, argv[i], l); p += l;
         }
         *p = '\0';
-        rc = agent_run(&cfg, msgs, tools, input, log);
+        rc = agent_run(&cfg, msgs, tools, input, log, &pending);
     } else {
         /* A human at a tty ends a turn with Enter ('\n'); a driving program
            (pipe/FIFO) ends each turn with a NUL byte, letting one turn carry
@@ -647,12 +703,13 @@ int main(int argc, char **argv) {
             if (!strcmp(input, "/quit") || !strcmp(input, "/exit")) {
                 free(input); break;
             }
-            agent_run(&cfg, msgs, tools, input, log);
+            agent_run(&cfg, msgs, tools, input, log, &pending);
             free(input);
             printf("\n<<TURN_COMPLETE>>\n");
             fflush(stdout);
         }
     }
+    compact_stop(&pending);
     cJSON_Delete(msgs); cJSON_Delete(tools); free(sysprompt);
     if (log) fclose(log);
     return rc;

--- a/src/test.c
+++ b/src/test.c
@@ -2,6 +2,14 @@
 #include "subzeroclaw.c"
 #include <assert.h>
 
+static int write_temp(const char *prefix, const char *data, char *out, size_t out_size) {
+    snprintf(out, out_size, "/tmp/.szc_%s_XXXXXX", prefix);
+    int fd = mkstemp(out); assert(fd >= 0);
+    FILE *f = fdopen(fd, "w"); assert(f);
+    assert(fputs(data, f) >= 0); assert(fclose(f) == 0);
+    return 0;
+}
+
 static int tests_passed = 0;
 static int tests_failed = 0;
 

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -1,0 +1,214 @@
+"""Exercise the shipped loop/protocol against an in-process HTTP provider."""
+import json
+import os
+from pathlib import Path
+import queue
+import subprocess
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+BIN = Path(__file__).resolve().parents[1] / "subzeroclaw"
+
+
+def answer(text="ok", compact=False, tool=False, finish="stop"):
+    message = {"role": "assistant", "content": text}
+    if tool:
+        message["tool_calls"] = [{
+            "id": "call-1", "type": "function",
+            "function": {"name": "shell", "arguments": json.dumps({"command": "printf tool-ok"})},
+        }]
+    return {"choices": [{"finish_reason": finish, "message": message}],
+            "x_router": {"compact": compact}}
+
+
+class RuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="szc-integration-")
+        self.addCleanup(self.tmp.cleanup)
+        self.home = Path(self.tmp.name)
+        config = self.home / ".subzeroclaw"
+        config.mkdir()
+        (config / "config").write_text("max_turns=30\n")
+        self.requests = []
+        self.compactions = []
+        self.compact_started = threading.Event()
+        self.release_compact = threading.Event()
+        self.addCleanup(self.release_compact.set)
+        self.compact_status = 200
+        self.compact_body = {"messages": [{"role": "system", "content": "SEALED"}]}
+        self.chat = lambda body: answer()
+        case = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_):
+                pass
+
+            def do_POST(self):
+                body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+                if self.path == "/v1/compact":
+                    case.compactions.append(body)
+                    response, status = case.compact_body, case.compact_status
+                    case.compact_started.set()
+                    case.release_compact.wait(10)
+                else:
+                    case.requests.append(body)
+                    response, status = case.chat(body), 200
+                payload = json.dumps(response).encode()
+                try:
+                    self.send_response(status)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(payload)))
+                    self.end_headers()
+                    self.wfile.write(payload)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+        self.addCleanup(self.server.server_close)
+        self.addCleanup(self.server.shutdown)
+        # Allowlist: never inherit provider keys, proxies, or the user's config.
+        env = {"PATH": os.environ["PATH"], "HOME": str(self.home),
+               "SUBZEROCLAW_API_KEY": "local-fixture-only",
+               "SUBZEROCLAW_ENDPOINT": f"http://127.0.0.1:{self.server.server_port}/v1/chat/completions",
+               "SUBZEROCLAW_COMPACT_EXTRA": '{"keep_recent":1}'}
+        self.proc = subprocess.Popen([str(BIN)], env=env, cwd=self.home,
+                                     stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE)
+        self.addCleanup(self.stop)
+        self.lines = queue.Queue()
+
+        def read_output():
+            for line in iter(self.proc.stdout.readline, b""):
+                self.lines.put(line)
+            self.lines.put(b"")
+
+        threading.Thread(target=read_output, daemon=True).start()
+
+    def stop(self):
+        if self.proc.poll() is None:
+            self.proc.stdin.close()
+            try:
+                self.proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait(timeout=3)
+                self.fail("runtime failed to shut down")
+        for stream in (self.proc.stdin, self.proc.stdout, self.proc.stderr):
+            stream.close()
+
+    def turn(self, prompt):
+        self.proc.stdin.write(prompt.encode() + b"\0")
+        self.proc.stdin.flush()
+        output = b""
+        while True:
+            line = self.lines.get(timeout=5)
+            self.assertTrue(line, "runtime exited before turn completion")
+            output += line
+            if b"<<TURN_COMPLETE>>" in line:
+                return output
+
+    def log(self):
+        return "".join(p.read_text() for p in (self.home / ".subzeroclaw/logs").glob("*.txt"))
+
+    def wait_for_seal(self, compact_again=False):
+        """Additional requests bound polling without assuming a scheduler delay."""
+        sealed = any(m.get("content") == "SEALED" for m in self.requests[-1]["messages"])
+        if sealed:
+            return answer("sealed-ok")
+        # One cheap local command gives the completed background process CPU time.
+        result = answer(tool=True, compact=compact_again)
+        result["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] = '{"command":"sleep 0.02"}'
+        return result
+
+    def test_compaction_survives_turns_and_keeps_new_input(self):
+        self.chat = lambda body: answer(compact=True)
+        self.turn("first")
+        self.assertTrue(self.compact_started.wait(3))
+        self.assertEqual(len(self.compactions), 1)
+        self.release_compact.set()
+        self.chat = lambda body: self.wait_for_seal()
+        self.assertIn(b"sealed-ok", self.turn("second"))
+        self.assertIn({"role": "user", "content": "second"}, self.requests[-1]["messages"])
+        self.assertIn("context compacted", self.log())
+
+    def test_failed_compaction_retries_without_losing_history(self):
+        self.compact_status = 503
+        self.release_compact.set()
+        self.chat = lambda body: answer(compact=True)
+        self.turn("first")
+        self.assertTrue(self.compact_started.wait(3))
+        self.compact_status = 200
+        self.chat = lambda body: self.wait_for_seal(compact_again=True)
+        self.assertIn(b"sealed-ok", self.turn("second"))
+        self.assertGreaterEqual(len(self.compactions), 2)
+        self.assertIn("compaction failed; history retained", self.log())
+
+    def test_snapshot_has_paired_tools_and_finish_alias_runs_tool(self):
+        def chat(body):
+            if len(self.requests) == 1:
+                return answer(tool=True, compact=True, finish="tool_use")
+            return answer("tool-finished")
+        self.chat = chat
+        self.assertIn(b"tool-finished", self.turn("first"))
+        self.assertTrue(self.compact_started.wait(3))
+        messages = self.compactions[0]["messages"]
+        self.assertEqual(messages[-1]["role"], "tool")
+        self.assertEqual(messages[-1]["tool_call_id"], "call-1")
+        self.assertIn("tool-ok", messages[-1]["content"])
+
+    def test_one_pending_compaction_and_shutdown_cleanup(self):
+        self.chat = lambda body: answer(compact=True)
+        self.turn("first")
+        self.assertTrue(self.compact_started.wait(3))
+        self.turn("second")
+        self.assertEqual(len(self.compactions), 1)
+        # Linux procfs identifies only this runtime's own private directory.
+        children_path = Path(f"/proc/{self.proc.pid}/task/{self.proc.pid}/children")
+        if not children_path.exists():
+            self.skipTest("process cleanup inspection requires Linux procfs")
+        children = children_path.read_text().split()
+        self.assertEqual(len(children), 1)
+        child = children[0]
+        curl_children = Path(f"/proc/{child}/task/{child}/children").read_text().split()
+        self.assertEqual(len(curl_children), 1)
+        args = Path(f"/proc/{curl_children[0]}/cmdline").read_bytes().split(b"\0")
+        body_arg = args[args.index(b"--data-binary") + 1].decode()
+        paths = [Path(body_arg[1:]).parent]
+        self.assertTrue(paths)
+        self.stop()
+        self.assertFalse(Path(f"/proc/{child}").exists())
+        self.assertTrue(all(not path.exists() for path in paths))
+
+    def test_empty_compaction_does_not_erase_history(self):
+        self.compact_body = {"messages": []}
+        self.release_compact.set()
+        self.chat = lambda body: answer(compact=True)
+        self.turn("first")
+        self.assertTrue(self.compact_started.wait(3))
+        def chat(body):
+            if "invalid compaction response" in self.log():
+                return answer("retained-ok")
+            return self.wait_for_seal()
+        self.chat = chat
+        self.assertIn(b"retained-ok", self.turn("second"))
+        self.assertIn({"role": "user", "content": "first"}, self.requests[-1]["messages"])
+
+    def test_endpoint_metacharacters_cannot_execute_a_host_command(self):
+        marker = self.home / "must-not-exist"
+        endpoint = (f"http://127.0.0.1:{self.server.server_port}/v1/chat/completions"
+                    f"'; touch '{marker}'; #")
+        env = {"PATH": os.environ["PATH"], "HOME": str(self.home),
+               "SUBZEROCLAW_API_KEY": "local-fixture-only",
+               "SUBZEROCLAW_ENDPOINT": endpoint}
+        result = subprocess.run([str(BIN), "test"], env=env, cwd=self.home,
+                                capture_output=True, timeout=5)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(marker.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Background compaction state was scoped to one user turn, so completed seals could be lost between turns and shutdown could abandon HTTP work. Compaction is now owned by the session, includes complete tool-call/reply pairs, retains history on failed or empty seals, and cancels/reaps pending work on normal shutdown.

HTTP requests use curl argv and private header/body files instead of interpolated shell commands. Existing structured tool-call finish-reason compatibility is preserved after integrating current main.

Validation: 32 unit tests and six real-executable loopback integration tests pass, covering multi-turn compaction, failure/retry, cleanup, tool replies and command-injection rejection. PR CI runs both test targets. No provider credentials or paid requests are used. Abrupt SIGKILL/host-loss cleanup is not guaranteed.

This runtime PR accompanies the Genswarms core stabilization; consumer gitlink updates will be separate PRs.

Companion: [Genswarms #98](https://github.com/genlayerlabs/genswarms/pull/98).
